### PR TITLE
[FEAT] 프로모션 CRUD Search 구현 및 AOP로깅 기능 추가

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/aspect/LoggingAspectCommon.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/aspect/LoggingAspectCommon.java
@@ -1,0 +1,40 @@
+package com.tk.gg.common.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j(topic = "CommonLogging")
+public class LoggingAspectCommon {
+
+    // 매서드 실행 전후로 로그 기록
+    // 메서드 실행 시간 측정
+    // Service 클래스에 적용
+    @Around(
+            "execution(* com.tk.gg..*Service.*(..))"
+    )
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        String methodName = joinPoint.getSignature().getName();
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+
+        long startTime = System.currentTimeMillis();
+        log.info("메서드 실행 시작 - 클래스명: {}, 메서드명: {}", className, methodName);
+
+        Object result = null;
+        try {
+            result = joinPoint.proceed(); // 실제 메서드 실행
+        } catch (Throwable ex) {
+            log.error("예외 발생 - 클래스명: {}, 메서드명: {}, 예외 메시지: {}", className, methodName, ex.getMessage());
+            throw ex; // 예외를 다시 던져줍니다.
+        }
+
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        log.info("메서드 실행 종료 - 클래스명: {}, 메서드명: {}, 실행 시간: {}ms", className, methodName, elapsedTime);
+
+        return result;
+    }
+}

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/jpa/JpaConfig.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/jpa/JpaConfig.java
@@ -1,5 +1,8 @@
 package com.tk.gg.common.jpa;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -11,4 +14,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
 }

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
@@ -4,7 +4,12 @@ public enum ResponseMessage {
     POST_CREATE_SUCCESS("게시글이 성공적으로 생성되었습니다."),
     POST_UPDATE_SUCCESS("게시글이 성공적으로 수정되었습니다."),
     POST_DELETE_SUCCESS("게시글이 성공적으로 삭제되었습니다."),
-    POST_RETRIEVE_SUCCESS("게시글을 성공적으로 조회했습니다.");
+    POST_RETRIEVE_SUCCESS("게시글을 성공적으로 조회했습니다."),
+    // 프로모션 관련 메시지
+    PROMOTION_CREATE_SUCCESS("프로모션을 성공적으로 생성했습니다."),
+    PROMOTION_UPDATE_SUCCESS("프로모션을 성공적으로 수정했습니다."),
+    PROMOTION_DELETE_SUCCESS("프로모션을 성공적으로 삭제했습니다."),
+    PROMOTION_RETRIEVE_SUCCESS("프로모션을 성공적으로 조회했습니다.");
     // 다른 메시지들...
 
     private final String message;

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -14,8 +14,10 @@ public enum GlowGlowError {
 
 
     // Post (게시판 관련 에러)
-    POST_NO_EXIST(404,"POST_001","존재하지 않은 게시물입니다.")
+    POST_NO_EXIST(404,"POST_001","존재하지 않은 게시물입니다."),
 
+    // 프로모션 관련 에러
+    PROMOTION_NO_EXIST(404, "PROMOTION_001", "존재하지 않은 프로모션입니다.")
     ;
 
     private final int statusCode; // HTTP 상태 코드

--- a/promotion/src/main/java/com/tk/gg/promotion/PromotionApplication.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/PromotionApplication.java
@@ -3,9 +3,13 @@ package com.tk.gg.promotion;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+@ComponentScan(basePackages = {"com.tk.gg", "com.tk.gg.common"})
 public class PromotionApplication {
 
     public static void main(String[] args) {

--- a/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
@@ -1,0 +1,30 @@
+package com.tk.gg.promotion.application;
+
+import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.domain.service.PromotionDomainService;
+import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionApplicationService {
+    private final PromotionDomainService promotionDomainService;
+
+    public PromotionResponseDto createPromotion(PromotionCreateRequestDto requestDto) {
+        // DTO -> 도메인 변환
+        Promotion promotion = Promotion.builder()
+                .postUserId(1L)
+                .title(requestDto.getTitle())
+                .description(requestDto.getDescription())
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .status(requestDto.getStatus())
+                .build();
+
+        Promotion savedPromotion = promotionDomainService.createPromotion(promotion);
+
+        return PromotionResponseDto.from(savedPromotion);
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
@@ -3,7 +3,7 @@ package com.tk.gg.promotion.application;
 import com.tk.gg.promotion.application.dto.PromotionResponseDto;
 import com.tk.gg.promotion.domain.Promotion;
 import com.tk.gg.promotion.domain.service.PromotionDomainService;
-import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
+import com.tk.gg.promotion.application.dto.PromotionRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +14,7 @@ import java.util.UUID;
 public class PromotionApplicationService {
     private final PromotionDomainService promotionDomainService;
 
-    public PromotionResponseDto createPromotion(PromotionCreateRequestDto requestDto) {
+    public PromotionResponseDto createPromotion(PromotionRequestDto requestDto) {
         // DTO -> 도메인 변환
         Promotion promotion = Promotion.builder()
                 .postUserId(1L)
@@ -33,5 +33,26 @@ public class PromotionApplicationService {
     public PromotionResponseDto getPromotion(UUID promotionId) {
         Promotion promotion = promotionDomainService.getPromotion(promotionId);
         return PromotionResponseDto.from(promotion);
+    }
+
+    public PromotionResponseDto updatePromotion(UUID promotionId, PromotionRequestDto requestDto) {
+        // DTO -> 도메인 변환
+        Promotion promotion = Promotion.builder()
+                .promotionId(promotionId)
+                .postUserId(1L)
+                .title(requestDto.getTitle())
+                .description(requestDto.getDescription())
+                .startDate(requestDto.getStartDate())
+                .endDate(requestDto.getEndDate())
+                .status(requestDto.getStatus())
+                .build();
+
+        Promotion updatedPromotion = promotionDomainService.updatePromotion(promotion);
+
+        return PromotionResponseDto.from(updatedPromotion);
+    }
+
+    public void deletePromotion(UUID promotionId) {
+        promotionDomainService.deletePromotion(promotionId);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
@@ -7,6 +7,8 @@ import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class PromotionApplicationService {
@@ -26,5 +28,10 @@ public class PromotionApplicationService {
         Promotion savedPromotion = promotionDomainService.createPromotion(promotion);
 
         return PromotionResponseDto.from(savedPromotion);
+    }
+
+    public PromotionResponseDto getPromotion(UUID promotionId) {
+        Promotion promotion = promotionDomainService.getPromotion(promotionId);
+        return PromotionResponseDto.from(promotion);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/PromotionApplicationService.java
@@ -1,10 +1,13 @@
 package com.tk.gg.promotion.application;
 
 import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.application.dto.PromotionSearch;
 import com.tk.gg.promotion.domain.Promotion;
 import com.tk.gg.promotion.domain.service.PromotionDomainService;
 import com.tk.gg.promotion.application.dto.PromotionRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -54,5 +57,9 @@ public class PromotionApplicationService {
 
     public void deletePromotion(UUID promotionId) {
         promotionDomainService.deletePromotion(promotionId);
+    }
+
+    public Page<PromotionResponseDto> searchPromotions(Pageable pageable, PromotionSearch condition) {
+        return promotionDomainService.searchPromotions(pageable, condition);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionCreateRequestDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.tk.gg.promotion.application.dto;
+
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+public class PromotionCreateRequestDto {
+    private String title;
+    private String description;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+    private PromotionStatus status;
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionRequestDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionRequestDto.java
@@ -7,7 +7,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDate;
 
 @Data
-public class PromotionCreateRequestDto {
+public class PromotionRequestDto {
     private String title;
     private String description;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionResponseDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionResponseDto.java
@@ -1,5 +1,6 @@
 package com.tk.gg.promotion.application.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.tk.gg.promotion.domain.Promotion;
 import com.tk.gg.promotion.domain.enums.PromotionStatus;
 import lombok.Builder;
@@ -18,6 +19,17 @@ public class PromotionResponseDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private PromotionStatus status;
+
+    @QueryProjection
+    public PromotionResponseDto(Long postUserId, UUID promotionId, String title, String description, LocalDate startDate, LocalDate endDate, PromotionStatus status) {
+        this.postUserId = postUserId;
+        this.promotionId = promotionId;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
 
     public static PromotionResponseDto from(Promotion promotion) {
         return PromotionResponseDto.builder()

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionResponseDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionResponseDto.java
@@ -1,0 +1,33 @@
+package com.tk.gg.promotion.application.dto;
+
+import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@Builder
+public class PromotionResponseDto {
+    private Long postUserId;
+    private UUID promotionId;
+    private String title;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private PromotionStatus status;
+
+    public static PromotionResponseDto from(Promotion promotion) {
+        return PromotionResponseDto.builder()
+                .postUserId(promotion.getPostUserId())
+                .promotionId(promotion.getPromotionId())
+                .title(promotion.getTitle())
+                .description(promotion.getDescription())
+                .startDate(promotion.getStartDate())
+                .endDate(promotion.getEndDate())
+                .status(promotion.getStatus())
+                .build();
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionSearch.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/PromotionSearch.java
@@ -1,0 +1,14 @@
+package com.tk.gg.promotion.application.dto;
+
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class PromotionSearch {
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private PromotionStatus status;
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/Coupon.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/Coupon.java
@@ -1,0 +1,85 @@
+package com.tk.gg.promotion.domain;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import com.tk.gg.promotion.domain.enums.CouponStatus;
+import com.tk.gg.promotion.domain.enums.DiscountType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_coupons")
+@Getter
+@SQLRestriction("is_delete is false")
+@SQLDelete(sql = "UPDATE p_coupons SET deleted_at = NOW() where coupon_id = ?")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "coupon_id")
+    private UUID couponId;
+
+    @ManyToOne
+    @JoinColumn(name = "promotion_id")
+    private Promotion promotion;
+
+    @Column(name = "code", nullable = false)
+    private String code;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "discount", nullable = false)
+    private BigDecimal discount;
+
+    @Column(name = "max_discount", nullable = false)
+    private String maxDiscount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_type", nullable = false)
+    private DiscountType discountType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private CouponStatus status = CouponStatus.ACTIVE;
+
+    @Column(name = "valid_from", nullable = false)
+    private LocalDateTime validFrom;
+
+    @Column(name = "valid_until", nullable = false)
+    private LocalDateTime validUntil;
+
+    @Column(name = "total_qauantity", nullable = false)
+    private Integer totalQuantity;
+
+    @Column(name = "is_delete", nullable = false)
+    private boolean isDelete = false;
+
+    @Builder
+    public Coupon(Promotion promotion,
+                  String code,
+                  String description,
+                  BigDecimal discount,
+                  String maxDiscount,
+                  DiscountType discountType,
+                  LocalDateTime validFrom,
+                  LocalDateTime validUntil,
+                  Integer totalQuantity) {
+        this.promotion = promotion;
+        this.code = code;
+        this.description = description;
+        this.discount = discount;
+        this.maxDiscount = maxDiscount;
+        this.discountType = discountType;
+        this.validFrom = validFrom;
+        this.validUntil = validUntil;
+        this.totalQuantity = totalQuantity;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/CouponUser.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/CouponUser.java
@@ -1,0 +1,43 @@
+package com.tk.gg.promotion.domain;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_coupon_users")
+@Getter
+@SQLRestriction("is_delete is false")
+@SQLDelete(sql = "UPDATE p_coupons_users SET deleted_at = NOW() where coupon_user_id = ?")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class CouponUser extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "coupon_user_id")
+    private UUID couponUserId;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "is_used", nullable = false)
+    private boolean isUsed = false;
+
+    @Column(name = "is_delete", nullable = false)
+    private boolean isDelete = false;
+
+    @Builder
+    public CouponUser(Coupon coupon, UUID userId) {
+        this.coupon = coupon;
+        this.userId = userId;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
@@ -1,0 +1,56 @@
+package com.tk.gg.promotion.domain;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_promotions")
+@Getter
+@SQLRestriction("is_delete is false")
+@SQLDelete(sql = "UPDATE p_promotions SET deleted_at = NOW() where promotion_id = ?")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Promotion extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "promotion_id")
+    private UUID promotionId;
+
+    @OneToMany(mappedBy = "promotion")
+    private List<Coupon> coupons = new ArrayList<>();
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate;
+
+    @Column(name = "is_delete", nullable = false)
+    private boolean isDelete = false;
+
+    @Builder
+    public Promotion(String title,
+                     String description,
+                     LocalDateTime startDate,
+                     LocalDateTime endDate) {
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Table(name = "p_promotions")
 @Getter
 @SQLRestriction("is_delete is false")
-@SQLDelete(sql = "UPDATE p_promotions SET deleted_at = NOW() where promotion_id = ?")
+@SQLDelete(sql = "UPDATE p_promotions SET deleted_at = NOW(), is_delete = true where promotion_id = ?")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Promotion extends BaseEntity {
     @Id
@@ -60,5 +60,13 @@ public class Promotion extends BaseEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.status = status;
+    }
+
+    public void update(Promotion promotion) {
+        this.title = promotion.title;
+        this.description = promotion.description;
+        this.startDate = promotion.startDate;
+        this.endDate = promotion.endDate;
+        this.status = promotion.status;
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/Promotion.java
@@ -1,6 +1,7 @@
 package com.tk.gg.promotion.domain;
 
 import com.tk.gg.common.jpa.BaseEntity;
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +29,9 @@ public class Promotion extends BaseEntity {
     @OneToMany(mappedBy = "promotion")
     private List<Coupon> coupons = new ArrayList<>();
 
+    @Column(name = "post_user_id", nullable = false)
+    private Long postUserId;
+
     @Column(name = "title", nullable = false)
     private String title;
 
@@ -35,22 +39,26 @@ public class Promotion extends BaseEntity {
     private String description;
 
     @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date", nullable = false)
-    private LocalDateTime endDate;
+    private LocalDate endDate;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PromotionStatus status;
 
     @Column(name = "is_delete", nullable = false)
     private boolean isDelete = false;
 
     @Builder
-    public Promotion(String title,
-                     String description,
-                     LocalDateTime startDate,
-                     LocalDateTime endDate) {
+    public Promotion(UUID promotionId, Long postUserId, String title, String description, LocalDate startDate, LocalDate endDate, PromotionStatus status) {
+        this.promotionId = promotionId;
+        this.postUserId = postUserId;
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.status = status;
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/enums/CouponStatus.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/enums/CouponStatus.java
@@ -1,0 +1,14 @@
+package com.tk.gg.promotion.domain.enums;
+
+public enum CouponStatus {
+    ACTIVE("활성화"),
+    EXPIRED("만료"),
+    USED("사용됨");
+
+
+    final String description;
+
+    CouponStatus(String description) {
+        this.description = description;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/enums/DiscountType.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/enums/DiscountType.java
@@ -1,0 +1,12 @@
+package com.tk.gg.promotion.domain.enums;
+
+public enum DiscountType {
+    PERCENTAGE("퍼센트"),
+    AMOUNT("금액");
+
+    final String description;
+
+    DiscountType(String description) {
+        this.description = description;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/enums/PromotionStatus.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/enums/PromotionStatus.java
@@ -1,0 +1,12 @@
+package com.tk.gg.promotion.domain.enums;
+
+public enum PromotionStatus {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화");
+
+    final String status;
+
+    PromotionStatus(String status) {
+        this.status = status;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/repository/PromotionRepositoryCustom.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/repository/PromotionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.tk.gg.promotion.domain.repository;
+
+import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.application.dto.PromotionSearch;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PromotionRepositoryCustom {
+    Page<PromotionResponseDto> findPromotionsByCondition(PromotionSearch condition, Pageable pageable);
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
@@ -1,0 +1,18 @@
+package com.tk.gg.promotion.domain.service;
+
+import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.infrastructure.PromotionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionDomainService {
+    private final PromotionRepository promotionRepository;
+
+    @Transactional
+    public Promotion createPromotion(Promotion promotion) {
+        return promotionRepository.save(promotion);
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
@@ -26,4 +26,23 @@ public class PromotionDomainService {
         return promotionRepository.findById(promotionId)
                 .orElseThrow(() -> new GlowGlowException(PROMOTION_NO_EXIST));
     }
+
+    @Transactional
+    public Promotion updatePromotion(Promotion promotion) {
+        // TODO: 회원 도메인 추가 후 본인 확인 로직 추가 필요.
+        Promotion savedPromotion = promotionRepository.findById(promotion.getPromotionId())
+                .orElseThrow(() -> new GlowGlowException(PROMOTION_NO_EXIST));
+        // 더티 체킹 업데이트
+        savedPromotion.update(promotion);
+        return savedPromotion;
+    }
+
+    @Transactional
+    public void deletePromotion(UUID promotionId) {
+        // TODO: 회원 도메인 추가 후 본인 확인 로직 추가 필요. deletedBy 추가 필요
+
+        Promotion promotion = promotionRepository.findById(promotionId)
+                .orElseThrow(() -> new GlowGlowException(PROMOTION_NO_EXIST));
+        promotionRepository.delete(promotion);
+    }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
@@ -1,10 +1,15 @@
 package com.tk.gg.promotion.domain.service;
 
+import com.tk.gg.common.response.exception.GlowGlowException;
 import com.tk.gg.promotion.domain.Promotion;
 import com.tk.gg.promotion.infrastructure.PromotionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.tk.gg.common.response.exception.GlowGlowError.*;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +19,11 @@ public class PromotionDomainService {
     @Transactional
     public Promotion createPromotion(Promotion promotion) {
         return promotionRepository.save(promotion);
+    }
+
+    @Transactional(readOnly = true)
+    public Promotion getPromotion(UUID promotionId) {
+        return promotionRepository.findById(promotionId)
+                .orElseThrow(() -> new GlowGlowException(PROMOTION_NO_EXIST));
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/PromotionDomainService.java
@@ -1,9 +1,13 @@
 package com.tk.gg.promotion.domain.service;
 
 import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.application.dto.PromotionSearch;
 import com.tk.gg.promotion.domain.Promotion;
 import com.tk.gg.promotion.infrastructure.PromotionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,5 +48,9 @@ public class PromotionDomainService {
         Promotion promotion = promotionRepository.findById(promotionId)
                 .orElseThrow(() -> new GlowGlowException(PROMOTION_NO_EXIST));
         promotionRepository.delete(promotion);
+    }
+
+    public Page<PromotionResponseDto> searchPromotions(Pageable pageable, PromotionSearch condition) {
+        return promotionRepository.findPromotionsByCondition(condition, pageable);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepository.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepository.java
@@ -1,9 +1,10 @@
 package com.tk.gg.promotion.infrastructure;
 
 import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.domain.repository.PromotionRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface PromotionRepository extends JpaRepository<Promotion, UUID> {
+public interface PromotionRepository extends JpaRepository<Promotion, UUID>, PromotionRepositoryCustom {
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepository.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepository.java
@@ -1,0 +1,9 @@
+package com.tk.gg.promotion.infrastructure;
+
+import com.tk.gg.promotion.domain.Promotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PromotionRepository extends JpaRepository<Promotion, UUID> {
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepositoryImpl.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/PromotionRepositoryImpl.java
@@ -1,0 +1,94 @@
+package com.tk.gg.promotion.infrastructure;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.application.dto.PromotionSearch;
+import com.tk.gg.promotion.application.dto.QPromotionResponseDto;
+import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
+import com.tk.gg.promotion.domain.repository.PromotionRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+import static com.tk.gg.promotion.domain.QPromotion.promotion;
+
+@Repository
+@RequiredArgsConstructor
+public class PromotionRepositoryImpl implements PromotionRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PromotionResponseDto> findPromotionsByCondition(PromotionSearch condition, Pageable pageable) {
+        List<PromotionResponseDto> promotions = queryFactory.select(
+                new QPromotionResponseDto(
+                        promotion.postUserId,
+                        promotion.promotionId,
+                        promotion.title,
+                        promotion.description,
+                        promotion.startDate,
+                        promotion.endDate,
+                        promotion.status
+                ))
+                .from(promotion)
+                .where(
+                        eqTitle(condition.getTitle()),
+                        eqStatus(condition.getStatus()),
+                        goeStartDate(condition.getStartDate()),
+                        loeEndDate(condition.getEndDate())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
+                .fetch();
+
+        // 카운트 쿼리 지연 로딩
+        JPAQuery<Promotion> count = queryFactory.selectFrom(promotion)
+                .where(
+                        eqTitle(condition.getTitle()),
+                        eqStatus(condition.getStatus()));
+
+        return PageableExecutionUtils.getPage(promotions, pageable, count::fetchCount);
+    }
+
+
+    // 정렬 조건 추가
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        return sort.stream()
+                .map(order -> {
+                    if ("createdAt".equals(order.getProperty())) {
+                        return order.isAscending() ? promotion.createdAt.asc() : promotion.createdAt.desc();
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private BooleanExpression eqTitle(String title) {
+        return StringUtils.hasText(title) ? promotion.title.eq(title) : null;
+    }
+
+    private BooleanExpression eqStatus(PromotionStatus status) {
+        return status != null ? promotion.status.eq(status) : null;
+    }
+
+    private BooleanExpression goeStartDate(LocalDate startDate) {
+        return startDate != null ? promotion.startDate.goe(startDate) : null;
+    }
+
+    private BooleanExpression loeEndDate(LocalDate endDate) {
+        return endDate != null ? promotion.endDate.loe(endDate) : null;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
@@ -4,7 +4,7 @@ import com.tk.gg.common.response.ApiUtils;
 import com.tk.gg.common.response.GlobalResponse;
 import com.tk.gg.common.response.ResponseMessage;
 import com.tk.gg.promotion.application.PromotionApplicationService;
-import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
+import com.tk.gg.promotion.application.dto.PromotionRequestDto;
 import com.tk.gg.promotion.application.dto.PromotionResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ public class PromotionController {
      * @return: 프로모션 생성 응답 DTO
      */
     @PostMapping
-    public GlobalResponse<PromotionResponseDto> createPromotion(@RequestBody PromotionCreateRequestDto requestDto) {
+    public GlobalResponse<PromotionResponseDto> createPromotion(@RequestBody PromotionRequestDto requestDto) {
         PromotionResponseDto promotion = promotionApplicationService.createPromotion(requestDto);
         return ApiUtils.success(ResponseMessage.PROMOTION_CREATE_SUCCESS.getMessage(), promotion);
     }
@@ -45,5 +45,35 @@ public class PromotionController {
     public GlobalResponse<PromotionResponseDto> getPromotion(@PathVariable("promotionId") UUID promotionId) {
         PromotionResponseDto promotion = promotionApplicationService.getPromotion(promotionId);
         return ApiUtils.success(ResponseMessage.PROMOTION_RETRIEVE_SUCCESS.getMessage(), promotion);
+    }
+
+    /**
+     * 프로모션 수정
+     * @param promotionId: 프로모션 ID
+     * @param requestDto: 프로모션 수정 요청 DTO <br>
+     *                  - title: 프로모션 제목  <br>
+     *                  - description: 프로모션 설명 <br>
+     *                  - startDate: 프로모션 시작일 <br>
+     *                  - endDate: 프로모션 종료일 <br>
+     *                  - status: 프로모션 상태 <br>
+     *
+     * @return: 프로모션 수정 응답 DTO
+     */
+    @PutMapping("/{promotionId}")
+    public GlobalResponse<PromotionResponseDto> updatePromotion(@PathVariable("promotionId") UUID promotionId,
+                                                                @RequestBody PromotionRequestDto requestDto) {
+        PromotionResponseDto promotion = promotionApplicationService.updatePromotion(promotionId, requestDto);
+        return ApiUtils.success(ResponseMessage.PROMOTION_UPDATE_SUCCESS.getMessage(), promotion);
+    }
+
+    /**
+     * 프로모션 삭제
+     * @param promotionId: 프로모션 ID
+     * @return: 프로모션 삭제 응답 DTO
+     */
+    @DeleteMapping("/{promotionId}")
+    public GlobalResponse<UUID> deletePromotion(@PathVariable("promotionId") UUID promotionId) {
+        promotionApplicationService.deletePromotion(promotionId);
+        return ApiUtils.success(ResponseMessage.PROMOTION_DELETE_SUCCESS.getMessage(), promotionId);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
@@ -1,0 +1,40 @@
+package com.tk.gg.promotion.presentation.controller;
+
+import com.tk.gg.common.response.ApiUtils;
+import com.tk.gg.common.response.GlobalResponse;
+import com.tk.gg.common.response.ResponseMessage;
+import com.tk.gg.promotion.application.PromotionApplicationService;
+import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
+import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j(topic = "PROMOTION_CONTROLLER")
+@RequestMapping("/api/promotions")
+public class PromotionController {
+    private final PromotionApplicationService promotionApplicationService;
+
+    /**
+     * 프로모션 생성
+     * @param requestDto: 프로모션 생성 요청 DTO <br>
+     *                  - title: 프로모션 제목  <br>
+     *                  - description: 프로모션 설명 <br>
+     *                  - startDate: 프로모션 시작일 <br>
+     *                  - endDate: 프로모션 종료일 <br>
+     *                  - status: 프로모션 상태 <br>
+     *
+     * @return: 프로모션 생성 응답 DTO
+     */
+    @PostMapping
+    public GlobalResponse<PromotionResponseDto> createPromotion(@RequestBody PromotionCreateRequestDto requestDto) {
+        PromotionResponseDto promotion = promotionApplicationService.createPromotion(requestDto);
+        return ApiUtils.success(ResponseMessage.PROMOTION_CREATE_SUCCESS.getMessage(), promotion);
+    }
+
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
@@ -6,8 +6,11 @@ import com.tk.gg.common.response.ResponseMessage;
 import com.tk.gg.promotion.application.PromotionApplicationService;
 import com.tk.gg.promotion.application.dto.PromotionRequestDto;
 import com.tk.gg.promotion.application.dto.PromotionResponseDto;
+import com.tk.gg.promotion.application.dto.PromotionSearch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -75,5 +78,27 @@ public class PromotionController {
     public GlobalResponse<UUID> deletePromotion(@PathVariable("promotionId") UUID promotionId) {
         promotionApplicationService.deletePromotion(promotionId);
         return ApiUtils.success(ResponseMessage.PROMOTION_DELETE_SUCCESS.getMessage(), promotionId);
+    }
+
+    /**
+     * 프로모션 검색 및 페이징 조회
+     * @param pageable: 페이징 정보
+     *                - page: 페이지 번호 <br>
+     *                - size: 페이지 크기 <br>
+     *                - sort: 정렬 정보 <br>
+     * @param condition: 프로모션 검색 조건
+     *                 - title: 프로모션 제목 <br>
+     *                 - status: 프로모션 상태 <br>
+     *                 - startDate: 프로모션 시작일 <br>
+     *                 - endDate: 프로모션 종료일 <br>
+     * @return: 프로모션 검색 및 페이징 조회 응답 DTO
+     */
+    @GetMapping
+    public GlobalResponse<Page<PromotionResponseDto>> searchPromotions(
+            Pageable pageable,
+            PromotionSearch condition
+    ) {
+        Page<PromotionResponseDto> promotionResponseDtos = promotionApplicationService.searchPromotions(pageable, condition);
+        return ApiUtils.success(ResponseMessage.PROMOTION_RETRIEVE_SUCCESS.getMessage(), promotionResponseDtos);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/PromotionController.java
@@ -8,10 +8,9 @@ import com.tk.gg.promotion.application.dto.PromotionCreateRequestDto;
 import com.tk.gg.promotion.application.dto.PromotionResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,4 +36,14 @@ public class PromotionController {
         return ApiUtils.success(ResponseMessage.PROMOTION_CREATE_SUCCESS.getMessage(), promotion);
     }
 
+    /**
+     * 프로모션 단건 조회
+     * @param promotionId: 프로모션 ID
+     * @return: 프로모션 단건 조회 응답 DTO
+     */
+    @GetMapping("/{promotionId}")
+    public GlobalResponse<PromotionResponseDto> getPromotion(@PathVariable("promotionId") UUID promotionId) {
+        PromotionResponseDto promotion = promotionApplicationService.getPromotion(promotionId);
+        return ApiUtils.success(ResponseMessage.PROMOTION_RETRIEVE_SUCCESS.getMessage(), promotion);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close: #20 


## 📝 작업 내용 요약

> - 프로모션 CRUD, Search(페이징 및 검색) 구현
>   - 검색 조건 및 정렬조건은 API문서에 최신화 하도록 하겠습니다.
> - common 모듈에 Service 모듈 로깅 추가

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

https://github.com/final-T/GlowGrow/blob/70556098ccb1c926eed0e34d2928adae380d4c11/promotion/src/main/java/com/tk/gg/promotion/PromotionApplication.java#L12

> 이 부분 처럼 커먼모듈도 컴포넌트 스캔 가능하도록 설정하면 AOP로깅 작동합니다. 사용하실 분은 적용하시면 됩니다!


## 🔗 관련 링크 (선택)
[포로모션 페이징 및 검색 조회 api](https://www.notion.so/teamsparta/API-cac7cc40b89e41ec9ea493fa3c8a7a62?p=8655d8aea0b94991acef476da2f5b2fd&pm=s)
