### PR TITLE
[FEAT] 게시판 좋아요 기능 구현

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
@@ -7,6 +7,10 @@ public enum ResponseMessage {
     POST_DELETE_SUCCESS("게시글이 성공적으로 삭제되었습니다."),
     POST_RETRIEVE_SUCCESS("게시글을 성공적으로 조회했습니다."),
 
+    // 좋아요 관련 메시지
+    LIKE_SUCCESS("게시물에 좋아요를 표시했습니다."),
+    UNLIKE_SUCCESS("게시물의 좋아요를 취소했습니다."),
+
     // 프로모션 관련 메시지
     PROMOTION_CREATE_SUCCESS("프로모션을 성공적으로 생성했습니다."),
     PROMOTION_UPDATE_SUCCESS("프로모션을 성공적으로 수정했습니다."),

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -15,6 +15,8 @@ public enum GlowGlowError {
 
     // Post (게시판 관련 에러)
     POST_NO_EXIST(404,"POST_001","존재하지 않은 게시물입니다."),
+    POST_LIKE_UPDATE_FAILED(404, "LIKE_001", "게시물 좋아요 업데이트에 실패했습니다."),
+
 
     // 프로모션 관련 에러
     PROMOTION_NO_EXIST(404, "PROMOTION_001", "존재하지 않은 프로모션입니다.")

--- a/post/src/main/java/com/tk/gg/post/application/dto/LikeResponseDto.java
+++ b/post/src/main/java/com/tk/gg/post/application/dto/LikeResponseDto.java
@@ -1,0 +1,15 @@
+package com.tk.gg.post.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class LikeResponseDto {
+    private UUID postId;
+    private Long userId;
+    private boolean likeStatus;
+    private int likeCount;
+}

--- a/post/src/main/java/com/tk/gg/post/application/service/LikeService.java
+++ b/post/src/main/java/com/tk/gg/post/application/service/LikeService.java
@@ -1,0 +1,37 @@
+package com.tk.gg.post.application.service;
+
+import com.tk.gg.post.application.dto.LikeResponseDto;
+import com.tk.gg.post.domain.model.Like;
+import com.tk.gg.post.domain.model.Post;
+import com.tk.gg.post.domain.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PostService postService;
+
+    @Transactional
+    public LikeResponseDto toggleLike(UUID postId, Long userId) {
+        Post post = postService.getPostById(postId);
+
+        Like like = likeRepository.findFirstByPostAndUserId(post, userId)
+                .orElse(new Like(post, userId));
+
+        // 좋아요 상태 토글
+        like.toggleLikeStatus();
+        likeRepository.save(like);
+
+        Post updatedPost = postService.updatePostLikeCount(postId, like.getLikeStatus());
+
+        return new LikeResponseDto(postId, userId, like.getLikeStatus(), updatedPost.getLikes());
+    }
+
+}

--- a/post/src/main/java/com/tk/gg/post/domain/model/Like.java
+++ b/post/src/main/java/com/tk/gg/post/domain/model/Like.java
@@ -1,0 +1,44 @@
+package com.tk.gg.post.domain.model;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "like_id", updatable = false, nullable = false)
+    private UUID likeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "like_status", nullable = false)
+    private Boolean likeStatus = false;
+
+    @Builder
+    public Like(Post post, Long userId) {
+        this.post = post;
+        this.userId = userId;
+        this.likeStatus = false;
+    }
+
+    public void toggleLikeStatus() {
+        this.likeStatus = !this.likeStatus;
+    }
+
+}

--- a/post/src/main/java/com/tk/gg/post/domain/model/Post.java
+++ b/post/src/main/java/com/tk/gg/post/domain/model/Post.java
@@ -29,6 +29,7 @@ public class Post extends BaseEntity {
     @Column(name = "views", nullable = false)
     private Integer views;
 
+    @Setter
     @Column(name = "likes", nullable = false)
     private Integer likes;
 

--- a/post/src/main/java/com/tk/gg/post/domain/repository/LikeRepository.java
+++ b/post/src/main/java/com/tk/gg/post/domain/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.tk.gg.post.domain.repository;
+
+import com.tk.gg.post.domain.model.Like;
+import com.tk.gg.post.domain.model.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LikeRepository extends JpaRepository<Like, UUID> {
+    Optional<Like> findFirstByPostAndUserId(Post post, Long userId);
+}

--- a/post/src/main/java/com/tk/gg/post/domain/repository/PostRepository.java
+++ b/post/src/main/java/com/tk/gg/post/domain/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package com.tk.gg.post.domain.repository;
 
 import com.tk.gg.post.domain.model.Post;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,5 +23,12 @@ public interface PostRepository extends JpaRepository<Post, UUID> , PostReposito
 
     @Query(value = "SELECT views FROM Post WHERE postId = :postId")
     int getViews(@Param("postId") UUID postId);
+
+
+    @Modifying
+    @Query(value = "UPDATE p_posts SET likes = likes + CASE WHEN :likeStatus THEN 1 ELSE -1 END " +
+            "WHERE post_id = :postId AND (likes > 0 OR :likeStatus = true)",
+            nativeQuery = true)
+    int updateLikeCount(@Param("postId") UUID postId, @Param("likeStatus") boolean likeStatus);
 
 }

--- a/post/src/main/java/com/tk/gg/post/presentation/controller/LikeController.java
+++ b/post/src/main/java/com/tk/gg/post/presentation/controller/LikeController.java
@@ -1,0 +1,29 @@
+package com.tk.gg.post.presentation.controller;
+
+import com.tk.gg.common.response.ApiUtils;
+import com.tk.gg.common.response.GlobalResponse;
+import com.tk.gg.common.response.ResponseMessage;
+import com.tk.gg.post.application.dto.LikeResponseDto;
+import com.tk.gg.post.application.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class LikeController {
+    private final LikeService likeService;
+
+    @PostMapping("/{postId}/like")
+    public GlobalResponse<LikeResponseDto> toggleLike(@PathVariable UUID postId) {
+        Long userId = 1L;
+        LikeResponseDto responseDto = likeService.toggleLike(postId, userId);
+
+        ResponseMessage responseMessage = responseDto.isLikeStatus()
+                ? ResponseMessage.LIKE_SUCCESS
+                : ResponseMessage.UNLIKE_SUCCESS;
+        return ApiUtils.success(responseMessage.getMessage(), responseDto);
+    }
+}

--- a/post/src/test/java/com/tk/gg/post/PostServiceTest.java
+++ b/post/src/test/java/com/tk/gg/post/PostServiceTest.java
@@ -1,0 +1,71 @@
+package com.tk.gg.post;
+
+import com.tk.gg.post.application.service.PostService;
+import com.tk.gg.post.domain.model.Post;
+import com.tk.gg.post.domain.repository.PostRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+//TODO : 좋아요 수 떨어지는 것도 동시성 여부 체크 필요?
+
+@SpringBootTest
+@Transactional
+@Slf4j
+public class PostServiceTest {
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private UUID postId;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트를 위한 게시물 생성
+//        Post post = Post.createPostBuilder()
+//                .postRequestDto(new PostRequestDto("Test Title", "Test Content"))
+//                .build();
+//        postRepository.save(post);
+        postId = UUID.fromString("c4e50cbb-2b04-4536-b0a8-08d1832f7b57");
+    }
+
+    @Test
+    @Transactional
+    void multiThreadsLikesTest() throws InterruptedException {
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 여러 사용자가 동시에 좋아요를 누름
+        for (int i = 0; i < numberOfThreads; i++) {
+            Long userId = (long) i;  // 각 사용자마다 고유한 ID 할당
+            executorService.execute(() -> {
+                try {
+                    postService.updatePostLikeCount(postId, true);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 스레드가 완료될 때까지 대기
+        latch.await();
+
+        // 게시물 좋아요 수 검증
+        Post post = postService.getPostById(postId);
+        assertThat(post.getLikes()).isEqualTo(numberOfThreads);
+        // 결과 확인을 위한 print문
+        System.out.println("테스트 성공: 게시물 좋아요 수가 " + post.getLikes() + "로 예상한 수치와 일치합니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#39 

## 📝 작업 내용 요약

- 게시판 좋아요 기능 구현
- 공통 예외 & 응답 메시지 추가
- 좋아요 동시성 테스트 코드 추가

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7e254998-02a9-4c5f-ae09-c906e5f99bd9)
- 100개의 스레드를 생성하여 100명의 사용자가 동시에 좋아요를 누르는 상황을 시뮬레이션
![image](https://github.com/user-attachments/assets/74c162cc-ff5a-47d5-975e-e170f2fb85c8)
- 최종 좋아요 수가 스레드의 수(100)와 일치 : 동시성 문제 X


## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
