### PR TITLE
[FEAT] 발급된 쿠폰 조회 및 사용 구현, 쿠폰 상태 스케줄러 처리

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
         - id: promotion-service # 프로모션 서비스
           uri: lb://promotion-service
           predicates:
-            - Path=/api/promotions/**, /api/coupons/**
+            - Path=/api/promotions/**, /api/coupons/**, /api/my-coupons/**
         - id: chat-service # 채팅 서비스
           uri: lb://chat-service
           predicates:

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/CouponUserResponseDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/CouponUserResponseDto.java
@@ -1,0 +1,41 @@
+package com.tk.gg.promotion.application.dto;
+
+import com.tk.gg.promotion.domain.CouponUser;
+import com.tk.gg.promotion.domain.enums.CouponStatus;
+import com.tk.gg.promotion.domain.enums.DiscountType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@Builder
+public class CouponUserResponseDto {
+    private UUID couponId;
+    private UUID promotionId;
+    private String description;
+    private DiscountType discountType;
+    private BigDecimal discountValue;
+    private BigDecimal maxDiscount;
+    private LocalDate validFrom;
+    private LocalDate validUntil;
+    private CouponStatus status;
+    private Boolean isUsed;
+
+    public static CouponUserResponseDto from(CouponUser couponUser) {
+        return CouponUserResponseDto.builder()
+                .couponId(couponUser.getCoupon().getCouponId())
+                .promotionId(couponUser.getCoupon().getPromotion().getPromotionId())
+                .description(couponUser.getCoupon().getDescription())
+                .discountType(couponUser.getCoupon().getDiscountType())
+                .discountValue(couponUser.getCoupon().getDiscountValue())
+                .maxDiscount(couponUser.getCoupon().getMaxDiscount())
+                .validFrom(couponUser.getCoupon().getValidFrom())
+                .validUntil(couponUser.getCoupon().getValidUntil())
+                .status(couponUser.getCoupon().getStatus())
+                .isUsed(couponUser.isUsed())
+                .build();
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/application/scheduler/PromotionAndCouponStatusScheduler.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/scheduler/PromotionAndCouponStatusScheduler.java
@@ -1,5 +1,7 @@
 package com.tk.gg.promotion.application.scheduler;
 
+import com.tk.gg.promotion.domain.enums.CouponStatus;
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
 import com.tk.gg.promotion.infrastructure.repository.PromotionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class PromotionStatusScheduler {
+public class PromotionAndCouponStatusScheduler {
     private final PromotionRepository promotionRepository;
 
     // 매일 자정에 실행
@@ -19,7 +21,17 @@ public class PromotionStatusScheduler {
     @Transactional
     public void updatePromotionStatus() {
         log.info("스케줄러 시작 - 기간이 지난 프로모션을 INACTIVE로 변경합니다.");
-        promotionRepository.updatePromotionStatus();
+        promotionRepository.updatePromotionStatus(PromotionStatus.INACTIVE, PromotionStatus.ACTIVE);
+        log.info("스케줄러 종료 - 상태 변경 완료.");
+    }
+
+    // 매일 자정에 실행
+    // 활성화 기간이 지난 쿠폰 상태를 만료로 변경
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void updateCouponStatus() {
+        log.info("스케줄러 시작 - 기간이 지난 쿠폰을 EXPIRED로 변경합니다.");
+        promotionRepository.updateCouponStatus(CouponStatus.EXPIRED, CouponStatus.ACTIVE);
         log.info("스케줄러 종료 - 상태 변경 완료.");
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
@@ -43,4 +43,9 @@ public class CouponApplicationService {
 
         return CouponUserResponseDto.from(userCoupon);
     }
+
+    // 쿠폰 사용 처리
+    public void useCoupon(Long userId, UUID couponId) {
+        couponDomainService.useCoupon(userId, couponId);
+    }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
@@ -1,13 +1,13 @@
 package com.tk.gg.promotion.application.serivce;
 
-import com.tk.gg.promotion.application.dto.CouponCreateRequestDto;
-import com.tk.gg.promotion.application.dto.CouponIssueRequestDto;
-import com.tk.gg.promotion.application.dto.CouponIssueResponseDto;
-import com.tk.gg.promotion.application.dto.CouponResponseDto;
+import com.tk.gg.promotion.application.dto.*;
 import com.tk.gg.promotion.domain.Coupon;
+import com.tk.gg.promotion.domain.CouponUser;
 import com.tk.gg.promotion.domain.service.CouponDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +24,15 @@ public class CouponApplicationService {
     // 쿠폰 발급
     public CouponIssueResponseDto issueCoupon(CouponIssueRequestDto requestDto) {
         return couponDomainService.issueCoupoon(requestDto);
+    }
+
+    // 사용자 쿠폰 목록 조회
+    public List<CouponUserResponseDto> getUserCoupons(Long userId) {
+        List<CouponUser> userCoupons = couponDomainService.getUserCoupons(userId);
+
+        return userCoupons.stream()
+                .map(CouponUserResponseDto::from)
+                .toList();
+
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/serivce/CouponApplicationService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -34,5 +35,12 @@ public class CouponApplicationService {
                 .map(CouponUserResponseDto::from)
                 .toList();
 
+    }
+
+    // 사용자 쿠폰 단건 조회
+    public CouponUserResponseDto getUserCoupon(Long userId, UUID couponId) {
+        CouponUser userCoupon = couponDomainService.getUserCoupon(userId, couponId);
+
+        return CouponUserResponseDto.from(userCoupon);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/CouponUser.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/CouponUser.java
@@ -40,4 +40,9 @@ public class CouponUser extends BaseEntity {
         this.coupon = coupon;
         this.userId = userId;
     }
+
+    // 쿠폰 사용 처리
+    public void useCoupon() {
+        this.isUsed = true;
+    }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/enums/CouponStatus.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/enums/CouponStatus.java
@@ -2,8 +2,7 @@ package com.tk.gg.promotion.domain.enums;
 
 public enum CouponStatus {
     ACTIVE("활성화"),
-    EXPIRED("만료"),
-    USED("사용됨");
+    EXPIRED("만료");
 
 
     final String description;

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
@@ -27,7 +27,7 @@ public class CouponDomainService {
     @Transactional
     public Coupon createCoupon(CouponCreateRequestDto requestDto) {
         Promotion promotion = promotionRepository.findById(requestDto.getPromotionId())
-                .orElseThrow(() -> new GlowGlowException(GlowGlowError.POST_NO_EXIST));
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.PROMOTION_NO_EXIST));
 
         // 쿠폰 생성 로직을 Promotion 애그리거트에서 처리
         return promotion.createCoupon(
@@ -45,7 +45,7 @@ public class CouponDomainService {
     public CouponIssueResponseDto issueCoupoon(CouponIssueRequestDto requestDto) {
         // 프로모션 조회
         Promotion promotion = promotionRepository.findById(requestDto.getPromotionId())
-                .orElseThrow(() -> new GlowGlowException(GlowGlowError.POST_NO_EXIST));
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.PROMOTION_NO_EXIST));
 
         // 발급하려는 쿠폰 조회
         Coupon coupon = promotion.getCoupons().stream()

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CouponDomainService {
@@ -73,5 +75,11 @@ public class CouponDomainService {
                 .couponDescription(coupon.getDescription())
                 .userId(couponUser.getUserId())
                 .build();
+    }
+
+    // 사용자 쿠폰 목록 조회
+    @Transactional(readOnly = true)
+    public List<CouponUser> getUserCoupons(Long userId) {
+        return couponUserRepository.findByUserId(userId);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/domain/service/CouponDomainService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -81,5 +82,12 @@ public class CouponDomainService {
     @Transactional(readOnly = true)
     public List<CouponUser> getUserCoupons(Long userId) {
         return couponUserRepository.findByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public CouponUser getUserCoupon(Long userId, UUID couponId) {
+
+        return couponUserRepository.findByUserIdAndCouponId(userId, couponId)
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.COUPON_NO_EXIST));
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/CouponUserRepository.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/CouponUserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -12,4 +13,6 @@ public interface CouponUserRepository extends JpaRepository<CouponUser, UUID> {
     @Query("SELECT COUNT(cu) > 0 FROM CouponUser cu WHERE cu.coupon.couponId = :couponId AND cu.userId = :userId")
     boolean existsByCouponAndUserId(UUID couponId, Long userId);
 
+    @Query("SELECT cu FROM CouponUser cu WHERE cu.userId = :userId")
+    List<CouponUser> findByUserId(Long userId);
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/CouponUserRepository.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/CouponUserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -15,4 +16,7 @@ public interface CouponUserRepository extends JpaRepository<CouponUser, UUID> {
 
     @Query("SELECT cu FROM CouponUser cu WHERE cu.userId = :userId")
     List<CouponUser> findByUserId(Long userId);
+
+    @Query("SELECT cu FROM CouponUser cu WHERE cu.userId = :userId AND cu.coupon.couponId = :couponId")
+    Optional<CouponUser> findByUserIdAndCouponId(Long userId, UUID couponId);
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/PromotionRepository.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/repository/PromotionRepository.java
@@ -1,10 +1,13 @@
 package com.tk.gg.promotion.infrastructure.repository;
 
 import com.tk.gg.promotion.domain.Promotion;
+import com.tk.gg.promotion.domain.enums.CouponStatus;
+import com.tk.gg.promotion.domain.enums.PromotionStatus;
 import com.tk.gg.promotion.domain.repository.PromotionRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
@@ -12,7 +15,12 @@ import java.util.UUID;
 @Repository
 public interface PromotionRepository extends JpaRepository<Promotion, UUID>, PromotionRepositoryCustom {
     @Modifying
-    @Query("UPDATE Promotion p SET p.status = 'INACTIVE' " +
-            "WHERE p.status = 'ACTIVE' AND p.endDate < CURRENT_DATE")
-    void updatePromotionStatus();
+    @Query("UPDATE Promotion p SET p.status = :inactiveStatus " +
+            "WHERE p.status = :activeStatus AND p.endDate < CURRENT_DATE")
+    void updatePromotionStatus(@Param("inactiveStatus") PromotionStatus inactiveStatus, @Param("activeStatus") PromotionStatus activeStatus);
+
+    @Modifying
+    @Query("UPDATE Coupon c SET c.status = :expiredStatus " +
+            "WHERE c.status = :activeStatus AND c.validUntil < CURRENT_DATE")
+    void updateCouponStatus(@Param("expiredStatus") CouponStatus expiredStatus, @Param("activeStatus") CouponStatus activeStatus);
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
@@ -8,10 +8,12 @@ import com.tk.gg.promotion.application.serivce.CouponApplicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,5 +32,17 @@ public class CoponUserController {
         Long userId = 1L;
         List<CouponUserResponseDto> userCoupons = couponApplicationService.getUserCoupons(userId);
         return ApiUtils.success(ResponseMessage.COUPON_USER_RETRIEVE_SUCCESS.getMessage(), userCoupons);
+    }
+
+    /**
+     * 사용자 쿠폰 단건 조회
+     */
+    @GetMapping("/{couponId}")
+    public GlobalResponse<CouponUserResponseDto> getUserCoupon(@PathVariable UUID couponId) {
+        // TODO : 헤더에 있는 사용자 ID로 사용자 쿠폰 목록 조회, 임시 값으로 1로 설정
+        Long userId = 1L;
+        CouponUserResponseDto userCoupon = couponApplicationService.getUserCoupon(userId, couponId);
+
+        return ApiUtils.success(ResponseMessage.COUPON_USER_RETRIEVE_SUCCESS.getMessage(), userCoupon);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
@@ -1,0 +1,34 @@
+package com.tk.gg.promotion.presentation.controller;
+
+import com.tk.gg.common.response.ApiUtils;
+import com.tk.gg.common.response.GlobalResponse;
+import com.tk.gg.common.response.ResponseMessage;
+import com.tk.gg.promotion.application.dto.CouponUserResponseDto;
+import com.tk.gg.promotion.application.serivce.CouponApplicationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j(topic = "COUPON_USER_CONTROLLER")
+@RequestMapping("/api/my-coupons")
+public class CoponUserController {
+    private final CouponApplicationService couponApplicationService;
+
+    /**
+     * 사용자 쿠폰 목록 조회
+     * @return: 사용자 쿠폰 목록 조회 응답 DTO
+     */
+    @GetMapping
+    public GlobalResponse<List<CouponUserResponseDto>> getUserCoupons() {
+        // TODO : 헤더에 있는 사용자 ID로 사용자 쿠폰 목록 조회, 임시 값으로 1로 설정
+        Long userId = 1L;
+        List<CouponUserResponseDto> userCoupons = couponApplicationService.getUserCoupons(userId);
+        return ApiUtils.success(ResponseMessage.COUPON_USER_RETRIEVE_SUCCESS.getMessage(), userCoupons);
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CoponUserController.java
@@ -7,10 +7,7 @@ import com.tk.gg.promotion.application.dto.CouponUserResponseDto;
 import com.tk.gg.promotion.application.serivce.CouponApplicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -44,5 +41,19 @@ public class CoponUserController {
         CouponUserResponseDto userCoupon = couponApplicationService.getUserCoupon(userId, couponId);
 
         return ApiUtils.success(ResponseMessage.COUPON_USER_RETRIEVE_SUCCESS.getMessage(), userCoupon);
+    }
+
+    /**
+     * 사용자 쿠폰 사용
+     * @param couponId: 쿠폰 ID
+     * @return: 사용자 쿠폰 사용 응답 DTO
+     */
+    @PatchMapping("{couponId}/use")
+    public GlobalResponse<Void> useCoupon(@PathVariable UUID couponId) {
+        // TODO : 헤더에 있는 사용자 ID로 사용자 쿠폰 사용, 임시 값으로 1로 설정
+        Long userId = 1L;
+        // 쿠폰 사용 처리
+        couponApplicationService.useCoupon(userId, couponId);
+        return ApiUtils.success(ResponseMessage.COUPON_USER_USE_SUCCESS.getMessage(), null);
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CouponController.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/presentation/controller/CouponController.java
@@ -3,17 +3,13 @@ package com.tk.gg.promotion.presentation.controller;
 import com.tk.gg.common.response.ApiUtils;
 import com.tk.gg.common.response.GlobalResponse;
 import com.tk.gg.common.response.ResponseMessage;
-import com.tk.gg.promotion.application.dto.CouponCreateRequestDto;
-import com.tk.gg.promotion.application.dto.CouponIssueRequestDto;
-import com.tk.gg.promotion.application.dto.CouponIssueResponseDto;
-import com.tk.gg.promotion.application.dto.CouponResponseDto;
+import com.tk.gg.promotion.application.dto.*;
 import com.tk.gg.promotion.application.serivce.CouponApplicationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,8 +32,14 @@ public class CouponController {
         return ApiUtils.success("쿠폰 생성 성공", coupon);
     }
 
-    @PostMapping("/issue")
-    public GlobalResponse<CouponIssueResponseDto> issueCoupon(@RequestBody CouponIssueRequestDto requestDto) {
+    /**
+     * 쿠폰 발급
+     *
+     * @param requestDto: 쿠폰 발급 요청 DTO
+     * @return: 쿠폰 발급 응답 DTO
+     */
+    @PostMapping("/{couponId}/issue")
+    public GlobalResponse<CouponIssueResponseDto> issueCoupon(@PathVariable UUID couponId, @RequestBody CouponIssueRequestDto requestDto) {
         // TODO : 권한 체크 (발급 대상자 유효성 검사 - 쿠폰 발급 대상자가 맞는지 확인)
         CouponIssueResponseDto couponIssueResponseDto = couponApplicationService.issueCoupon(requestDto);
         return ApiUtils.success(ResponseMessage.COUPON_USER_CREATE_SUCCESS.getMessage(), couponIssueResponseDto);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #37 

## 📝 작업 내용 요약

- 사용자의 쿠폰 리스트 조회
- 사용자의 쿠폰 단건 조회
- 쿠폰 사용 기능 구현
  - 쿠폰 사용자의 is_used필드 true 로 변경
- 쿠폰 사용가능 종료 날짜 지나면 매일 자정 스케줄러 처리 상태 변경
  - 쿠폰 사용기간이 지나면 상태를 EXPIRED 로 변경

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
