### PR TITLE
[FEAT] 게시판 조회시 댓글 리스트 기능 구현

### DIFF
--- a/post/src/main/java/com/tk/gg/post/application/dto/PostResponseDto.java
+++ b/post/src/main/java/com/tk/gg/post/application/dto/PostResponseDto.java
@@ -6,7 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -27,5 +29,33 @@ public class PostResponseDto {
                 .views(post.getViews())
                 .likes(post.getLikes())
                 .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Get{
+        private UUID postId;
+        private String title;
+        private String content;
+        private Integer views;
+        private Integer likes;
+        private List<CommentResponseDto> commentList;
+
+        public static Get of(Post post) {
+            return Get.builder()
+                    .postId(post.getPostId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .views(post.getViews())
+                    .likes(post.getLikes())
+                    .commentList(post.getComments().stream()
+                            .map(CommentResponseDto::of)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+
+
     }
 }

--- a/post/src/main/java/com/tk/gg/post/application/dto/PostSearchCondition.java
+++ b/post/src/main/java/com/tk/gg/post/application/dto/PostSearchCondition.java
@@ -6,10 +6,10 @@ import java.time.LocalDateTime;
 
 @Data
 public class PostSearchCondition {
+    private String title;
     private String keyword;
     private Integer minLikes;
     private Integer minViews;
     private LocalDateTime createdAt;
-
     //private Long userId;
 }

--- a/post/src/main/java/com/tk/gg/post/application/service/PostService.java
+++ b/post/src/main/java/com/tk/gg/post/application/service/PostService.java
@@ -60,7 +60,7 @@ public class PostService {
 
 
     @Transactional
-    public PostResponseDto getPost(UUID postId) {
+    public PostResponseDto.Get getPost(UUID postId) {
         Post post = postRepository.findByPostId(postId)
                 .orElseThrow(() -> new GlowGlowException(GlowGlowError.POST_NO_EXIST));
 
@@ -71,7 +71,7 @@ public class PostService {
         int updatedViews = postRepository.getViews(postId);
         post.setViews(updatedViews);
 
-        return PostResponseDto.of(post);
+        return PostResponseDto.Get.of(post);
     }
 
 

--- a/post/src/main/java/com/tk/gg/post/presentation/controller/PostController.java
+++ b/post/src/main/java/com/tk/gg/post/presentation/controller/PostController.java
@@ -30,24 +30,28 @@ public class PostController {
         return ApiUtils.success(ResponseMessage.POST_CREATE_SUCCESS.getMessage(),responseDto);
     }
 
+    // 게시글 전체 조회
     @GetMapping
     public  GlobalResponse<List<PostResponseDto>> getAllPosts(){
         List<PostResponseDto> responseDto = postService.getAllPosts();
         return ApiUtils.success(ResponseMessage.POST_RETRIEVE_SUCCESS.getMessage(),responseDto);
     }
 
+    // 게시글 조회
     @GetMapping("/{postId}")
-    public GlobalResponse<PostResponseDto> getPostById(@PathVariable UUID postId){
-        PostResponseDto responseDto = postService.getPost(postId);
+    public GlobalResponse<PostResponseDto.Get> getPostById(@PathVariable UUID postId){
+        PostResponseDto.Get responseDto = postService.getPost(postId);
         return ApiUtils.success(ResponseMessage.POST_RETRIEVE_SUCCESS.getMessage(),responseDto);
     }
 
+    // 게시글 수정
     @PatchMapping("/{postId}")
     public GlobalResponse<PostResponseDto> updatePost(@PathVariable UUID postId, @RequestBody PostRequestDto requestDto) {
         PostResponseDto responseDto = postService.updatePost(postId, requestDto);
         return ApiUtils.success(ResponseMessage.POST_UPDATE_SUCCESS.getMessage(), responseDto);
     }
 
+    // 게시글 삭제
     @DeleteMapping("/{postId}")
     public GlobalResponse<Void> deletePost(@PathVariable UUID postId) {
         postService.deletePost(postId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- <#52 >

## 📝 작업 내용 요약

- 게시판 조회 시 해당 게시물에 대한 댓글-답글을 같이 보여질 수 있도록 구현했습니다.
- 게시판 검색 시 정렬조건을 누락했을 때 기본정렬을 추가했습니다.
- 게시판 검색 시 title(제목) 조건을 추가했습니다.

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
