### PR TITLE
[FEAT] gateway swagger 통합 및 서비스 Config 설정

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/cors/WebConfig.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/cors/WebConfig.java
@@ -1,0 +1,17 @@
+package com.tk.gg.common.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 설정
+                .allowedOriginPatterns("http://localhost:*") // 모든 출처 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -46,3 +46,34 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/ # Eureka 서버의 URL을 지정
+
+
+springdoc:
+  swagger-ui:
+    path: /swagger
+    urls[0]:
+      name: reservation service
+      url: http://localhost:19092/v3/api-docs
+    urls[1]:
+      name: user service
+      url: http://localhost:19093/v3/api-docs
+    urls[2]:
+      name: notification service
+      url: http://localhost:19094/v3/api-docs
+    urls[3]:
+      name: notification service
+      url: http://localhost:19094/v3/api-docs
+    urls[4]:
+      name: post service
+      url: http://localhost:19095/v3/api-docs
+    urls[5]:
+      name: payment service
+      url: http://localhost:19096/v3/api-docs
+    urls[6]:
+      name: chat service
+      url: http://localhost:19097/v3/api-docs
+    urls[7]:
+      name: promotion service
+      url: http://localhost:19098/v3/api-docs
+
+

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/config/SwaggerConfig.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.tk.gg.promotion.infrastructure.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "Glow-Grow Promotion Service", version = "1.0.0", description = "팀 T키타카의 Glow-Grow 프로모션 서비스입니다.")
+)
+public class SwaggerConfig {
+    @Value("${gateway.url}")
+    private String gatewayURL;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
+                .addServersItem(new Server().url(gatewayURL));
+    }
+
+}

--- a/promotion/src/main/resources/application.yml
+++ b/promotion/src/main/resources/application.yml
@@ -23,3 +23,17 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+
+# springdoc-openapi-ui
+gateway:
+  url: http://localhost:19091
+springdoc:
+  api-docs:
+    version: openapi_3_1
+    enabled: true
+    path: /v3/api-docs
+    # 게이트웨이 라우팅에서 prefix를 제거하지 않았다면 해당 설정을 추가
+  enable-spring-security: true
+  default-consumes-media-type: application/json;charset=UTF-8 # 요청 객체 Data Type
+  default-produces-media-type: application/json;charset=UTF-8 # 응답 객체 Data Type


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - close #50 

## 📝 작업 내용 요약

> - gateway로 swagger 문서를 통합하도록 설정하였습니다.
> - 그에 따른 CORS 설정을 common모듈 작성하여 각 서비스에 적용될수 있도록 하였습니다.

### 📸 스크린샷 (선택)

> 
<img width="928" alt="image" src="https://github.com/user-attachments/assets/0e882615-4ab4-4d9c-ac88-947341bccfda">


## ❓ 리뷰 요청사항 (선택)

> 누락된 서비스 있으면 말씀해주세요!
> 각 서비스에 대한 설정 가이드 slack으로 공유하겠습니다!

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
