### PR TITLE
[FEAT] 사용자 쿠폰 발급 비동기 처리

### DIFF
--- a/promotion/build.gradle
+++ b/promotion/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     // For set objectMapper in redisFactory
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
 
+    implementation project(':GlowGrow-kafka')
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // lombok - 코드 간소화 (각 서비스 모듈에서도 추가 필요)
     compileOnly 'org.projectlombok:lombok'

--- a/promotion/src/main/java/com/tk/gg/promotion/application/dto/CouponIssueResponseDto.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/application/dto/CouponIssueResponseDto.java
@@ -8,13 +8,11 @@ import java.util.UUID;
 @Data
 public class CouponIssueResponseDto {
     private UUID couponId;
-    private String couponDescription;
     private Long userId;
 
     @Builder
-    public CouponIssueResponseDto(UUID couponId, String couponDescription, Long userId) {
+    public CouponIssueResponseDto(UUID couponId, Long userId) {
         this.couponId = couponId;
-        this.couponDescription = couponDescription;
         this.userId = userId;
     }
 }

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponIssueEvent.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponIssueEvent.java
@@ -1,0 +1,20 @@
+package com.tk.gg.promotion.infrastructure.messaging;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class CouponIssueEvent {
+    private UUID couponId;
+    private Long userId;
+
+    // 기본 생성자 추가
+    public CouponIssueEvent() {
+    }
+
+    public CouponIssueEvent(UUID couponId, Long userId) {
+        this.couponId = couponId;
+        this.userId = userId;
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponIssueEventHandler.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponIssueEventHandler.java
@@ -1,0 +1,37 @@
+package com.tk.gg.promotion.infrastructure.messaging;
+
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.promotion.domain.Coupon;
+import com.tk.gg.promotion.domain.CouponUser;
+import com.tk.gg.promotion.infrastructure.repository.CouponRepository;
+import com.tk.gg.promotion.infrastructure.repository.CouponUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j(topic = "COUPON-ISSUE-CONSUMER")
+@RequiredArgsConstructor
+public class CouponIssueEventHandler {
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
+
+    @KafkaListener(topics = "coupon-issue", groupId = "coupon-issue-group")
+    public void handleCouponIssueEvent(CouponIssueEvent couponIssueEvent) {
+        log.info("발급 이벤트 수신 : {}", couponIssueEvent);
+        // 발급하려는 쿠폰 조회
+        Coupon coupon = couponRepository.findById(couponIssueEvent.getCouponId())
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.COUPON_NO_EXIST));
+
+        // 쿠폰 사용자 생성
+        CouponUser couponUser = CouponUser.builder()
+                .coupon(coupon)
+                .userId(couponIssueEvent.getUserId())
+                .build();
+
+        couponUserRepository.save(couponUser);
+        log.info("발급 이벤트 처리 완료 : {}", couponIssueEvent);
+    }
+}

--- a/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponKafkaProducer.java
+++ b/promotion/src/main/java/com/tk/gg/promotion/infrastructure/messaging/CouponKafkaProducer.java
@@ -1,0 +1,20 @@
+package com.tk.gg.promotion.infrastructure.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j(topic = "COUPON-ISSUE-PRODUCER")
+@RequiredArgsConstructor
+public class CouponKafkaProducer {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendCouponIssueEvent(CouponIssueEvent couponIssueEvent) {
+
+        log.info("발급 이벤트 발행 : {}", couponIssueEvent);
+        kafkaTemplate.send("coupon-issue", couponIssueEvent);
+        log.info("발급 이벤트 발행 완료 : {}", couponIssueEvent);
+    }
+}

--- a/promotion/src/test/java/com/tk/gg/promotion/CouponIssuanceTest.java
+++ b/promotion/src/test/java/com/tk/gg/promotion/CouponIssuanceTest.java
@@ -84,7 +84,7 @@ class CouponIssuanceTest {
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void testConcurrentCouponIssuance() throws Exception {
         // 동시에 쿠폰 발급 요청
-        int threadCount = 200;
+        int threadCount = 1000;
         ExecutorService executorService = Executors.newFixedThreadPool(20);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -118,6 +118,10 @@ class CouponIssuanceTest {
 
         // 총 수행 시간 출력
         System.out.println("총 수행 시간: " + (end - start) + "ms");
+
+
+        // 비동기로 처리 되기 때문에 발급된 쿠폰 수량을 확인하기 위해 3초 대기
+        Thread.sleep(3000);
 
         int issuedCouponCount = couponUserRepository.countByCouponId(couponId);
         System.out.println("발급된 쿠폰 수량: " + issuedCouponCount);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #64 

## 📝 작업 내용 요약

> - 선착순 쿠폰 발급에 대해 Write DB에 트래픽이 몰리는 것을 방지하기 위해 Kafka를 활용합니다.
> -  비동기로 인해 테스트 코드 결과 조회 부분이 수정되었습니다.

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
