### PR TITLE
[FEAT] 평가정보 관리 기능 1차 구현

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/ResponseMessage.java
@@ -62,7 +62,10 @@ public enum ResponseMessage {
 
     REPORT_CREATE_SUCCESS("신고를 성공적으로 생성했습니다."),
     REPORT_RETRIEVE_SUCCESS("신고를 성공적으로 생성했습니다."),
-    REPORT_DELETE_SUCCESS("신고를 성공적으로 생성했습니다.")
+    REPORT_DELETE_SUCCESS("신고를 성공적으로 생성했습니다."),
+
+    // 평가 항목 관련 메시지
+    GRADE_RETRIEVE_SUCCESS("평가정보를 성공적으로 조회했습니다.")
 
     // 다른 메시지들...
     ;

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -63,7 +63,11 @@ public enum GlowGlowError {
     // 신고 관련 에러
     REPORT_NOT_OWNER(404, "REPORT_001", "해당 신고에 대한 권한이 없습니다."),
     REPORT_NO_EXIST(404, "REPORT_002","존재하지 않는 신고 정보 입니다."),
-    REPORT_ALREADY_EXIST(404, "REPORT_003", "이미 신고된 예약입니다.")
+    REPORT_ALREADY_EXIST(404, "REPORT_003", "이미 신고된 예약입니다."),
+
+    //평가항목 관련 에러
+    GRADE_NO_EXIST(404, "GRADE_001", "존재하지 않는 평가정보 입니다."),
+    GRADE_INVALID_ROLES(401, "GRADE_002","해당 평가정보에 대한 권한이 업습니다.")
     ;
     private final int statusCode; // HTTP 상태 코드
     private final String errorCode; // 내부 시스템의 에러 코드

--- a/reservation/build.gradle
+++ b/reservation/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
 	implementation project(':GlowGrow-common')
 	implementation project(':GlowGrow-security')
+	implementation project(':GlowGrow-kafka')
 
+	implementation 'org.springframework.kafka:spring-kafka'
 	// lombok - 코드 간소화 (각 서비스 모듈에서도 추가 필요)
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/reservation/src/main/java/com/tk/gg/reservation/application/dto/CustomerGradeDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/dto/CustomerGradeDto.java
@@ -1,0 +1,44 @@
+package com.tk.gg.reservation.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tk.gg.common.enums.UserRole;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CustomerGradeDto(
+        UUID id,
+        Long userId,
+        UserRole userType, // PROVIDER 또는 CUSTOMER
+        // 고객 평가 항목들
+        Integer customerCommunication,  // 고객 의사소통
+        Integer customerPunctuality,  // 고객 시간 준수
+        Integer customerManners,  // 고객 매너
+        Integer customerPaymentPromptness,  // 결제 신속성
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    @QueryProjection
+    public CustomerGradeDto(
+            UUID id,
+            Long userId,
+            UserRole userType,
+            Integer customerCommunication,
+            Integer customerPunctuality,
+            Integer customerManners,
+            Integer customerPaymentPromptness,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.userType = userType;
+        this.customerCommunication = customerCommunication;
+        this.customerPunctuality = customerPunctuality;
+        this.customerManners = customerManners;
+        this.customerPaymentPromptness = customerPaymentPromptness;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/application/dto/GradeDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/dto/GradeDto.java
@@ -1,0 +1,77 @@
+package com.tk.gg.reservation.application.dto;
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.reservation.domain.model.Grade;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Builder
+public record GradeDto(
+        UUID id,
+        Long userId,
+        UserRole userType, // PROVIDER 또는 CUSTOMER
+        // 제공자 (디자이너) 평가 항목들
+        Integer providerServiceQuality,  // 서비스 품질
+        Integer providerProfessionalism, // 전문성
+        Integer providerCommunication,  // 의사소통
+        Integer providerPunctuality,    // 시간 준수
+        Integer providerPriceSatisfaction,  // 가격 적정성
+        Integer customerCommunication,  // 고객 의사소통
+        Integer customerPunctuality,  // 고객 시간 준수
+        Integer customerManners,  // 고객 매너
+        Integer customerPaymentPromptness,  // 결제 신속성
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static GradeDto from(Grade entity) {
+        return GradeDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .userType(entity.getUserType())
+                .providerServiceQuality(entity.getProviderServiceQuality() != null ? entity.getProviderServiceQuality() : 0)
+                .providerProfessionalism(entity.getProviderProfessionalism() != null ? entity.getProviderProfessionalism() : 0)
+                .providerCommunication(entity.getProviderCommunication() != null ? entity.getProviderCommunication() : 0)
+                .providerPunctuality(entity.getProviderPunctuality() != null ? entity.getProviderPunctuality() : 0)
+                .providerPriceSatisfaction(entity.getProviderPriceSatisfaction() != null ? entity.getProviderPriceSatisfaction() : 0)
+                .customerCommunication(entity.getCustomerCommunication() != null ? entity.getCustomerCommunication() : 0)
+                .customerPunctuality(entity.getCustomerPunctuality() != null ? entity.getCustomerPunctuality() : 0)
+                .customerManners(entity.getCustomerManners() != null ? entity.getCustomerManners() : 0)
+                .customerPaymentPromptness(entity.getCustomerPaymentPromptness() != null ? entity.getCustomerPaymentPromptness() : 0)
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public static GradeDto from(CustomerGradeDto dto){
+        return GradeDto.builder()
+                .id(dto.id())
+                .userId(dto.userId())
+                .userType(dto.userType())
+                .customerCommunication(dto.customerCommunication())
+                .customerPunctuality(dto.customerPunctuality())
+                .customerManners(dto.customerManners())
+                .customerPaymentPromptness(dto.customerPaymentPromptness())
+                .createdAt(dto.createdAt())
+                .updatedAt(dto.updatedAt())
+                .build();
+    }
+
+    public static GradeDto from(ProviderGradeDto dto){
+        return GradeDto.builder()
+                .id(dto.id())
+                .userId(dto.userId())
+                .userType(dto.userType())
+                .providerServiceQuality(dto.providerServiceQuality())
+                .providerProfessionalism(dto.providerProfessionalism())
+                .providerCommunication(dto.providerCommunication())
+                .providerPunctuality(dto.providerPunctuality())
+                .providerPriceSatisfaction(dto.providerPriceSatisfaction())
+                .createdAt(dto.createdAt())
+                .updatedAt(dto.updatedAt())
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/application/dto/ProviderGradeDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/dto/ProviderGradeDto.java
@@ -1,0 +1,47 @@
+package com.tk.gg.reservation.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tk.gg.common.enums.UserRole;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ProviderGradeDto(
+        UUID id,
+        Long userId,
+        UserRole userType, // PROVIDER 또는 CUSTOMER
+        // 제공자 (디자이너) 평가 항목들
+        Integer providerServiceQuality,  // 서비스 품질
+        Integer providerProfessionalism, // 전문성
+        Integer providerCommunication,  // 의사소통
+        Integer providerPunctuality,    // 시간 준수
+        Integer providerPriceSatisfaction,  // 가격 적정성
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    @QueryProjection
+    public ProviderGradeDto(
+            UUID id,
+            Long userId,
+            UserRole userType,
+            Integer providerServiceQuality,
+            Integer providerProfessionalism,
+            Integer providerCommunication,
+            Integer providerPunctuality,
+            Integer providerPriceSatisfaction,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.userType = userType;
+        this.providerServiceQuality = providerServiceQuality;
+        this.providerProfessionalism = providerProfessionalism;
+        this.providerCommunication = providerCommunication;
+        this.providerPunctuality = providerPunctuality;
+        this.providerPriceSatisfaction = providerPriceSatisfaction;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/application/dto/ResultGradeDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/dto/ResultGradeDto.java
@@ -1,0 +1,27 @@
+package com.tk.gg.reservation.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ResultGradeDto(
+        Integer totalCount,
+        Integer totalProviderServiceQuality,
+        Integer totalProviderProfessionalism,
+        Integer totalProviderCommunication,
+        Integer totalProviderPunctuality,
+        Integer totalProviderPriceSatisfaction,
+        Integer totalCustomerCommunication,
+        Integer totalCustomerPunctuality,
+        Integer totalCustomerManners,
+        Integer totalCustomerPaymentPromptness,
+        Integer averageProviderServiceQuality,
+        Integer averageProviderProfessionalism,
+        Integer averageProviderCommunication,
+        Integer averageProviderPunctuality,
+        Integer averageProviderPriceSatisfaction,
+        Integer averageCustomerCommunication,
+        Integer averageCustomerPunctuality,
+        Integer averageCustomerManners,
+        Integer averageCustomerPaymentPromptness
+) {
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/application/service/GradeService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/service/GradeService.java
@@ -17,6 +17,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j(topic = "GRADE-UP-CONSUMER")
 @RequiredArgsConstructor
@@ -59,9 +60,13 @@ public class GradeService {
         }
     }
 
-    public GradeDto getGradeByUserId(Long userId) {
-        return GradeDto.from(gradeDomainService.getGradeByUserId(userId));
+    public GradeDto getGradeForUserAndReservation(Long userId, UUID reservationId) {
+        return GradeDto.from(gradeDomainService.getGradeForUserAndReservation(userId, reservationId));
     }
+    public GradeDto getGradeForUserAndReview(Long userId, UUID reviewId) {
+        return GradeDto.from(gradeDomainService.getGradeForUserAndReview(userId, reviewId));
+    }
+
 
     public ResultGradeDto getUserGradeSummary(Long userId, UserRole userType, Pageable pageable) {
         List<GradeDto> grades = getGradesByUserInfo(userId, userType, pageable).getContent();

--- a/reservation/src/main/java/com/tk/gg/reservation/application/service/GradeService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/service/GradeService.java
@@ -1,0 +1,136 @@
+package com.tk.gg.reservation.application.service;
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.reservation.application.dto.GradeDto;
+import com.tk.gg.reservation.application.dto.ResultGradeDto;
+import com.tk.gg.reservation.domain.service.GradeDomainService;
+import com.tk.gg.reservation.infrastructure.messaging.GradeForReservationEventDto;
+import com.tk.gg.reservation.infrastructure.messaging.GradeForReviewEventDto;
+import com.tk.gg.reservation.infrastructure.messaging.ToUserKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j(topic = "GRADE-UP-CONSUMER")
+@RequiredArgsConstructor
+@Service
+public class GradeService {
+
+    private final GradeDomainService gradeDomainService;
+//    private final ReviewDomainService reviewDomainService;
+    private final ToUserKafkaProducer userKafkaProducer;
+
+    // 예약 완료 -> 평가정보 반영 리스너 -> 이벤트 발행
+    @KafkaListener(topics = "grade-reservation", groupId = "grade-group")
+    public void handleGradeForReservation(GradeForReservationEventDto event) {
+        log.info("예약에 대한 평가반영 이벤트 수신 및 저장: {}", event);
+        //TODO : 예약 검증?
+        gradeDomainService.createGradeForReservation(event);
+        log.info("예약 -> 평가정보 저장 완료");
+        userKafkaProducer.sendGradeForReservationEventToUser(event);
+        log.info("유저에게 평가정보 업데이트 송신 완료");
+    }
+
+    // 리뷰 및 평점 작성 -> 평가정보 반영 리스너 -> 이벤트 발행
+    @KafkaListener(topics = "grade-review", groupId = "grade-group")
+    public void handleGradeForReview(GradeForReviewEventDto event) {
+        log.info("예약에 대한 평가반영 이벤트 수신: {}", event);
+        //TODO :  review 를 받을 때, 평가정보에 대한 내용도 받게 함
+//        gradeDomainService.updateGradeForReview();
+        log.info("예약 -> 평가정보 저장 완료");
+        userKafkaProducer.sendGradeForReviewEventToUser(event);
+        log.info("유저에게 평가정보 업데이트 송신 완료");
+    }
+
+    public Page<GradeDto> getGradesByUserInfo(Long userId, UserRole userType, Pageable pageable) {
+        if (userType == UserRole.CUSTOMER) {
+            return gradeDomainService.getCustomerGradesByUserInfo(userId, pageable).map(GradeDto::from);
+        } else if (userType == UserRole.PROVIDER) {
+            return gradeDomainService.getProviderGradesByUserInfo(userId, pageable).map(GradeDto::from);
+        } else {
+            throw new GlowGlowException(GlowGlowError.GRADE_INVALID_ROLES);
+        }
+    }
+
+    public GradeDto getGradeByUserId(Long userId) {
+        return GradeDto.from(gradeDomainService.getGradeByUserId(userId));
+    }
+
+    public ResultGradeDto getUserGradeSummary(Long userId, UserRole userType, Pageable pageable) {
+        List<GradeDto> grades = getGradesByUserInfo(userId, userType, pageable).getContent();
+
+        // 합계 변수 초기화
+        int totalProviderServiceQuality = 0;
+        int totalProviderProfessionalism = 0;
+        int totalProviderCommunication = 0;
+        int totalProviderPunctuality = 0;
+        int totalProviderPriceSatisfaction = 0;
+        int totalCustomerCommunication = 0;
+        int totalCustomerPunctuality = 0;
+        int totalCustomerManners = 0;
+        int totalCustomerPaymentPromptness = 0;
+
+        // 평가 수
+        int count = grades.size();
+
+        if (userType.equals(UserRole.PROVIDER)) {
+            for (GradeDto grade : grades) {
+                totalProviderServiceQuality += grade.providerServiceQuality();
+                totalProviderProfessionalism += grade.providerProfessionalism();
+                totalProviderCommunication += grade.providerCommunication();
+                totalProviderPunctuality += grade.providerPunctuality();
+                totalProviderPriceSatisfaction += grade.providerPriceSatisfaction();
+            }
+        } else if (userType.equals(UserRole.CUSTOMER)) {
+            for (GradeDto grade : grades) {
+                totalCustomerCommunication += grade.customerCommunication();
+                totalCustomerPunctuality += grade.customerPunctuality();
+                totalCustomerManners += grade.customerManners();
+                totalCustomerPaymentPromptness += grade.customerPaymentPromptness();
+            }
+        }
+
+        // 평균 계산 (평가 항목들이 없을 수 있으니 0으로 나누는 상황을 방지)
+        int averageProviderServiceQuality = totalProviderServiceQuality > 0 ? totalProviderServiceQuality / count : 0;
+        int averageProviderProfessionalism = totalProviderProfessionalism > 0 ? totalProviderProfessionalism / count : 0;
+        int averageProviderCommunication = totalProviderCommunication > 0 ? totalProviderCommunication / count : 0;
+        int averageProviderPunctuality = totalProviderPunctuality > 0 ? totalProviderPunctuality / count : 0;
+        int averageProviderPriceSatisfaction = totalProviderPriceSatisfaction > 0 ? totalProviderPriceSatisfaction / count : 0;
+
+        int averageCustomerCommunication = totalCustomerCommunication > 0 ? totalCustomerCommunication / count : 0;
+        int averageCustomerPunctuality = totalCustomerPunctuality > 0 ? totalCustomerPunctuality / count : 0;
+        int averageCustomerManners = totalCustomerManners > 0 ? totalCustomerManners / count : 0;
+        int averageCustomerPaymentPromptness = totalCustomerPaymentPromptness > 0 ? totalCustomerPaymentPromptness / count : 0;
+
+        // 결과 DTO 생성 및 반환
+        return ResultGradeDto.builder()
+                .totalCount(count)
+                .totalProviderServiceQuality(totalProviderServiceQuality)
+                .totalProviderProfessionalism(totalProviderProfessionalism)
+                .totalProviderCommunication(totalProviderCommunication)
+                .totalProviderPunctuality(totalProviderPunctuality)
+                .totalProviderPriceSatisfaction(totalProviderPriceSatisfaction)
+                .totalCustomerCommunication(totalCustomerCommunication)
+                .totalCustomerPunctuality(totalCustomerPunctuality)
+                .totalCustomerManners(totalCustomerManners)
+                .totalCustomerPaymentPromptness(totalCustomerPaymentPromptness)
+                .averageProviderServiceQuality(averageProviderServiceQuality)
+                .averageProviderProfessionalism(averageProviderProfessionalism)
+                .averageProviderCommunication(averageProviderCommunication)
+                .averageProviderPunctuality(averageProviderPunctuality)
+                .averageProviderPriceSatisfaction(averageProviderPriceSatisfaction)
+                .averageCustomerCommunication(averageCustomerCommunication)
+                .averageCustomerPunctuality(averageCustomerPunctuality)
+                .averageCustomerManners(averageCustomerManners)
+                .averageCustomerPaymentPromptness(averageCustomerPaymentPromptness)
+                .build();
+
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/model/Grade.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/model/Grade.java
@@ -23,7 +23,7 @@ public class Grade extends BaseEntity {
 
     @Column(name = "review_id")
     private UUID reviewId;
-    @Column(name = "reservation_id")
+    @Column(name = "reservation_id", nullable = false)
     private UUID reservationId;
 
     @Column(name = "user_id", nullable = false)

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/model/Grade.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/model/Grade.java
@@ -1,0 +1,77 @@
+package com.tk.gg.reservation.domain.model;
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.common.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Builder
+@Entity
+@Table(name = "p_grades")
+public class Grade extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "review_id")
+    private UUID reviewId;
+    @Column(name = "reservation_id")
+    private UUID reservationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "user_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole userType; // PROVIDER 또는 CUSTOMER
+
+    // 제공자 (디자이너) 평가 항목들
+    @Column(name = "service_quality")
+    private Integer providerServiceQuality;  // 서비스 품질
+
+    @Column(name = "professionalism")
+    private Integer providerProfessionalism;  // 전문성
+
+    @Column(name = "communication")
+    private Integer providerCommunication;  // 의사소통
+
+    @Column(name = "punctuality")
+    private Integer providerPunctuality;  // 시간 준수
+
+    @Column(name = "price_satisfaction")
+    private Integer providerPriceSatisfaction;  // 가격 적정성
+
+    // 고객 평가 항목들
+    @Column(name = "customer_communication")
+    private Integer customerCommunication;  // 고객 의사소통
+
+    @Column(name = "customer_punctuality")
+    private Integer customerPunctuality;  // 고객 시간 준수
+
+    @Column(name = "customer_manners")
+    private Integer customerManners;  // 고객 매너
+
+    @Column(name = "payment_promptness")
+    private Integer customerPaymentPromptness;  // 결제 신속성
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Grade grade = (Grade) o;
+        return Objects.equals(id, grade.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/model/Report.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/model/Report.java
@@ -34,6 +34,7 @@ public class Report extends BaseEntity {
     private Long targetUserId;
 
     @Column(name = "reporter_type")
+    @Enumerated(EnumType.STRING)
     private UserRole reporterType;
 
     private String reason;

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/model/Review.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/model/Review.java
@@ -23,7 +23,7 @@ public class Review extends BaseEntity {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id")
     private Reservation reservation;
 

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/repository/GradeRepositoryCustom.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/repository/GradeRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.tk.gg.reservation.domain.repository;
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.reservation.application.dto.CustomerGradeDto;
+import com.tk.gg.reservation.application.dto.ProviderGradeDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface GradeRepositoryCustom {
+    Page<CustomerGradeDto> getCustomerGradesByUserInfo(Long userId, Pageable pageable);
+    Page<ProviderGradeDto> getProviderGradesByUserInfo(Long userId, Pageable pageable);
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/service/GradeDomainService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/service/GradeDomainService.java
@@ -1,0 +1,54 @@
+package com.tk.gg.reservation.domain.service;
+
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.reservation.application.dto.CustomerGradeDto;
+import com.tk.gg.reservation.application.dto.ProviderGradeDto;
+import com.tk.gg.reservation.domain.model.Grade;
+import com.tk.gg.reservation.infrastructure.messaging.GradeForReservationEventDto;
+import com.tk.gg.reservation.infrastructure.repository.GradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Service
+public class GradeDomainService {
+
+    private final GradeRepository gradeRepository;
+
+    public Page<CustomerGradeDto> getCustomerGradesByUserInfo(Long userId, Pageable pageable) {
+        return gradeRepository.getCustomerGradesByUserInfo(userId, pageable);
+    }
+
+    public Page<ProviderGradeDto> getProviderGradesByUserInfo(Long userId, Pageable pageable) {
+        return gradeRepository.getProviderGradesByUserInfo(userId, pageable);
+    }
+
+    public void createGradeForReservation(GradeForReservationEventDto gradeForReservationDto) {
+        Grade customerGrade = Grade.builder().userId(gradeForReservationDto.customerId())
+                .userType(UserRole.CUSTOMER)
+                .reservationId(gradeForReservationDto.reservationId()).build();
+        Grade providerGrade = Grade.builder().userId(gradeForReservationDto.providerId())
+                .userType(UserRole.PROVIDER)
+                .reservationId(gradeForReservationDto.reservationId()).build();
+        gradeRepository.saveAll(List.of(customerGrade, providerGrade));
+    }
+
+    public Grade getGradeByUserId(Long userId){
+        return gradeRepository.findByUserId(userId).orElseThrow(
+                () -> new GlowGlowException(GlowGlowError.GRADE_NO_EXIST)
+        );
+    }
+
+
+    //TODO : 리뷰에 평가 기능 추가 후 구현
+    public void updateGradeForReview() {
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/service/GradeDomainService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/service/GradeDomainService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 
 @RequiredArgsConstructor
@@ -41,12 +42,17 @@ public class GradeDomainService {
         gradeRepository.saveAll(List.of(customerGrade, providerGrade));
     }
 
-    public Grade getGradeByUserId(Long userId){
-        return gradeRepository.findByUserId(userId).orElseThrow(
-                () -> new GlowGlowException(GlowGlowError.GRADE_NO_EXIST)
-        );
+    public Grade getGradeForUserAndReservation(Long userId, UUID reservationId) {
+        return gradeRepository.findByUserIdAndReservationId(userId, reservationId)
+                .orElseThrow(
+                        () -> new GlowGlowException(GlowGlowError.GRADE_NO_EXIST));
     }
 
+    public Grade getGradeForUserAndReview(Long userId, UUID reviewId) {
+        return gradeRepository.findByUserIdAndReviewId(userId, reviewId)
+                .orElseThrow(
+                        () -> new GlowGlowException(GlowGlowError.GRADE_NO_EXIST));
+    }
 
     //TODO : 리뷰에 평가 기능 추가 후 구현
     public void updateGradeForReview() {

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/config/ComponentScanConfig.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/config/ComponentScanConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackages = {"com.tk.gg.common","com.tk.gg.security"})
+@ComponentScan(basePackages = {"com.tk.gg.common"})
 public class ComponentScanConfig {
 }
+ 

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/GradeForReservationEventDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/GradeForReservationEventDto.java
@@ -1,0 +1,18 @@
+package com.tk.gg.reservation.infrastructure.messaging;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@JsonSerialize
+@JsonDeserialize
+@Builder
+public record GradeForReservationEventDto(
+        Long customerId,
+        Long providerId,
+        UUID reservationId
+) {
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/GradeForReviewEventDto.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/GradeForReviewEventDto.java
@@ -1,0 +1,20 @@
+package com.tk.gg.reservation.infrastructure.messaging;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.tk.gg.common.enums.UserRole;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@JsonSerialize
+@JsonDeserialize
+@Builder
+public record GradeForReviewEventDto(
+        Long reviewerId,
+        Long targetUserId,
+        UserRole userType,
+        UUID reviewId
+) {
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/ToUserKafkaProducer.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/messaging/ToUserKafkaProducer.java
@@ -1,0 +1,26 @@
+package com.tk.gg.reservation.infrastructure.messaging;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j(topic = "[GRADE-UP-PRODUCER]")
+@RequiredArgsConstructor
+public class ToUserKafkaProducer {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendGradeForReservationEventToUser(GradeForReservationEventDto event) {
+        log.info("예약에 대한 평가 정보 유저에게 발행: {}", event);
+        kafkaTemplate.send("grade-reservation-user", event);
+        log.info("평가정보 발행 완료");
+    }
+
+    public void sendGradeForReviewEventToUser(GradeForReviewEventDto event) {
+        log.info("예약에 대한 평가 정보 유저에게 발행: {}", event);
+        kafkaTemplate.send("grade-review-user", event);
+        log.info("평가정보 발행 완료");
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/repository/GradeRepository.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/repository/GradeRepository.java
@@ -1,0 +1,14 @@
+package com.tk.gg.reservation.infrastructure.repository;
+
+import com.tk.gg.reservation.domain.model.Grade;
+import com.tk.gg.reservation.domain.repository.GradeRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GradeRepository extends JpaRepository<Grade, UUID>, GradeRepositoryCustom {
+    Optional<Grade> findByUserIdAndReservationId(Long userId, UUID reservationId);
+    Optional<Grade> findByUserIdAndReviewId(Long userId, UUID reviewId);
+    Optional<Grade> findByUserId(Long userId);
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/infrastructure/repository/GradeRepositoryImpl.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/infrastructure/repository/GradeRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.tk.gg.reservation.infrastructure.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tk.gg.reservation.application.dto.CustomerGradeDto;
+import com.tk.gg.reservation.application.dto.ProviderGradeDto;
+import com.tk.gg.reservation.domain.model.QGrade;
+import com.tk.gg.reservation.domain.repository.GradeRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Repository
+public class GradeRepositoryImpl implements GradeRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    QGrade grade = QGrade.grade;
+
+
+    @Override
+    public Page<CustomerGradeDto> getCustomerGradesByUserInfo(Long userId, Pageable pageable) {
+        List<CustomerGradeDto> customerGrades = queryFactory
+                .select(Projections.fields(
+                        CustomerGradeDto.class,
+                        grade.id,
+                        grade.userId,
+                        grade.userType,
+                        grade.customerCommunication,
+                        grade.customerPunctuality,
+                        grade.customerManners,
+                        grade.customerPaymentPromptness,
+                        grade.createdAt,
+                        grade.updatedAt
+                ))
+                .from(grade)
+                .where(grade.userId.eq(userId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(grade.count())
+                .from(grade)
+                .where(grade.userId.eq(userId))
+                .fetchOne();
+
+        return new PageImpl<>(customerGrades, pageable, total);
+    }
+
+    @Override
+    public Page<ProviderGradeDto> getProviderGradesByUserInfo(Long userId, Pageable pageable) {
+        List<ProviderGradeDto> providerGrades = queryFactory
+                .select(Projections.fields(
+                        ProviderGradeDto.class,
+                        grade.id,
+                        grade.userId,
+                        grade.userType,
+                        grade.providerServiceQuality,
+                        grade.providerProfessionalism,
+                        grade.providerCommunication,
+                        grade.providerPunctuality,
+                        grade.createdAt,
+                        grade.updatedAt
+                ))
+                .from(grade)
+                .where(grade.userId.eq(userId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(grade.count())
+                .from(grade)
+                .where(grade.userId.eq(userId))
+                .fetchOne();
+
+        return new PageImpl<>(providerGrades, pageable, total);
+    }
+
+
+
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/GradeController.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/GradeController.java
@@ -1,0 +1,46 @@
+package com.tk.gg.reservation.presentation.controller;
+
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.common.response.ApiUtils;
+import com.tk.gg.common.response.GlobalResponse;
+import com.tk.gg.reservation.application.dto.ResultGradeDto;
+import com.tk.gg.reservation.application.service.GradeService;
+import com.tk.gg.reservation.presentation.response.GradeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static com.tk.gg.common.response.ResponseMessage.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/grades")
+public class GradeController {
+
+    private final GradeService gradeService;
+
+    @GetMapping()
+    public GlobalResponse<ResultGradeDto> getTotalGradeForUser(
+            @RequestParam(value = "userId") Long userId,
+            @RequestParam(value = "userType") UserRole userType,
+            @PageableDefault(sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiUtils.success(GRADE_RETRIEVE_SUCCESS.getMessage(),
+                gradeService.getUserGradeSummary(userId, userType, pageable));
+    }
+
+    @GetMapping("/users/{userId}")
+    public GlobalResponse<GradeResponse> getGradeForUserAndReservation(
+            @PathVariable(value = "userId") Long userId
+    ) {
+        return ApiUtils.success(GRADE_RETRIEVE_SUCCESS.getMessage(),
+                GradeResponse.from(gradeService.getGradeByUserId(userId))
+        );
+    }
+}

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/GradeController.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/GradeController.java
@@ -8,7 +8,6 @@ import com.tk.gg.reservation.application.dto.ResultGradeDto;
 import com.tk.gg.reservation.application.service.GradeService;
 import com.tk.gg.reservation.presentation.response.GradeResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -16,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-import static com.tk.gg.common.response.ResponseMessage.*;
+import static com.tk.gg.common.response.ResponseMessage.GRADE_RETRIEVE_SUCCESS;
 
 @RequiredArgsConstructor
 @RestController
@@ -35,12 +34,24 @@ public class GradeController {
                 gradeService.getUserGradeSummary(userId, userType, pageable));
     }
 
-    @GetMapping("/users/{userId}")
+
+    @GetMapping("/users/{userId}/reservations/{reservationId}")
     public GlobalResponse<GradeResponse> getGradeForUserAndReservation(
-            @PathVariable(value = "userId") Long userId
+            @PathVariable(value = "userId") Long userId,
+            @PathVariable(value = "reservationId") UUID reservationId
     ) {
         return ApiUtils.success(GRADE_RETRIEVE_SUCCESS.getMessage(),
-                GradeResponse.from(gradeService.getGradeByUserId(userId))
+                GradeResponse.from(gradeService.getGradeForUserAndReservation(userId, reservationId))
+        );
+    }
+
+    @GetMapping("/users/{userId}/reviews/{reviewId}")
+    public GlobalResponse<GradeResponse> getGradeForUserAndReview(
+            @PathVariable(value = "userId") Long userId,
+            @PathVariable(value = "reviewId") UUID reviewId
+    ) {
+        return ApiUtils.success(GRADE_RETRIEVE_SUCCESS.getMessage(),
+                GradeResponse.from(gradeService.getGradeForUserAndReview(userId, reviewId))
         );
     }
 }

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/response/GradeResponse.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/response/GradeResponse.java
@@ -1,0 +1,47 @@
+package com.tk.gg.reservation.presentation.response;
+
+import com.tk.gg.common.enums.UserRole;
+import com.tk.gg.reservation.application.dto.GradeDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record GradeResponse(
+        UUID id,
+        Long userId,
+        UserRole userType, // PROVIDER 또는 CUSTOMER
+        // 제공자 (디자이너) 평가 항목들
+        Integer providerServiceQuality,  // 서비스 품질
+        Integer providerProfessionalism, // 전문성
+        Integer providerCommunication,  // 의사소통
+        Integer providerPunctuality,    // 시간 준수
+        Integer providerPriceSatisfaction,  // 가격 적정성
+        Integer customerCommunication,  // 고객 의사소통
+        Integer customerPunctuality,  // 고객 시간 준수
+        Integer customerManners,  // 고객 매너
+        Integer customerPaymentPromptness,  // 결제 신속성
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static GradeResponse from(GradeDto dto) {
+        return GradeResponse.builder()
+                .id(dto.id())
+                .userId(dto.userId())
+                .userType(dto.userType())
+                .providerServiceQuality(dto.providerServiceQuality())
+                .providerProfessionalism(dto.providerProfessionalism())
+                .providerCommunication(dto.providerCommunication())
+                .providerPunctuality(dto.providerPunctuality())
+                .providerPriceSatisfaction(dto.providerPriceSatisfaction())
+                .customerCommunication(dto.customerCommunication())
+                .customerPunctuality(dto.customerPunctuality())
+                .customerManners(dto.customerManners())
+                .customerPaymentPromptness(dto.customerPaymentPromptness())
+                .createdAt(dto.createdAt())
+                .updatedAt(dto.updatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#16 

## 📝 작업 내용 요약

- 평가정보관리 `Grade` 엔티티 작성
- 유저에 대한 Grade 조회
  1. 유저 ID 와 예약 ID
  2. 유저 ID 와  리뷰 ID
  3. 유저 ID 및 유저 Role 로 종합 평가 조회 (total, average) 

TODO
- 리뷰에서 평가 정보 관련 요청을 받고 넘기는 로직을 구현해야함
- 공통 모듈에 평가정보관련 DTO 추가
