### PR TITLE
[FEAT] 결제 기능 구현 

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -37,6 +37,11 @@ public enum GlowGlowError {
     IMAGE_FILE_SIZE_EXCEEDED(404,"MULTIMEDIA_004","이미지 파일 크기가 허용된 최대 크기를 초과했습니다."),
     VIDEO_FILE_SIZE_EXCEEDED(404,"MULTIMEDIA_005","동영상 파일 크기가 허용된 최대 크기를 초과했습니다."),
 
+    // Payment (결제 관련 에러)
+    PAYMENT_NO_EXIST(404,"PAYMENT_001","존재하지 않은 결제정보입니다."),
+    PAYMENT_AMOUNT_MISMATCH(404,"PAYMENT_002","결제 금액이 일치하지 않습니다."),
+    ALREADY_APPROVED(404,"PAYMENT_003","이미 승인된 결제입니다."),
+
 
 
     // 프로모션 관련 에러

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -1,23 +1,11 @@
-plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.3.4'
-    id 'io.spring.dependency-management' version '1.1.6'
-}
-
-group = 'com.tk.gg'
-version = '0.0.1-SNAPSHOT'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
-repositories {
-    mavenCentral()
-}
+jar.enabled = true
 
 dependencies {
+    implementation project(':GlowGrow-common')
+    implementation project(':GlowGrow-security')
+
+    //implementation 'net.minidev:json-smart:2.4.9'
+
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/payment/src/main/java/com/tk/gg/payment/PaymentApplication.java
+++ b/payment/src/main/java/com/tk/gg/payment/PaymentApplication.java
@@ -3,9 +3,13 @@ package com.tk.gg.payment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+@ComponentScan(basePackages = {"com.tk.gg", "com.tk.gg.common","com.tk.gg.security"})
 public class PaymentApplication {
 
     public static void main(String[] args) {

--- a/payment/src/main/java/com/tk/gg/payment/application/client/UserService.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/client/UserService.java
@@ -1,0 +1,5 @@
+package com.tk.gg.payment.application.client;
+
+public interface UserService {
+    boolean isUserExistsByEmail(String email);
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/client/UserServiceImpl.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/client/UserServiceImpl.java
@@ -1,0 +1,23 @@
+package com.tk.gg.payment.application.client;
+
+import com.tk.gg.common.response.GlobalResponse;
+import com.tk.gg.payment.infrastructure.client.UserFeignClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class UserServiceImpl implements UserService {
+
+    private final UserFeignClient userFeignClient;
+
+    @Override
+    public boolean isUserExistsByEmail(String email) {
+        GlobalResponse<Boolean> response = userFeignClient.findByEmail(email);
+        log.info("Feign response for email {}: data={}, message={}",
+                email, response.getData(), response.getMessage());
+        return response.getData();
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentFailDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentFailDto.java
@@ -1,0 +1,17 @@
+package com.tk.gg.payment.application.dto;
+
+import com.tk.gg.payment.domain.model.Payment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentFailDto {
+    String errorCode;
+    String errorMessage;
+    String orderId;
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentRequestDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentRequestDto.java
@@ -1,0 +1,42 @@
+package com.tk.gg.payment.application.dto;
+
+import com.tk.gg.payment.domain.model.Payment;
+import com.tk.gg.payment.domain.type.PayType;
+import com.tk.gg.payment.domain.type.PaymentStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaymentRequestDto {
+    // 결제 호출 요청용 Dto
+
+    @NotNull(message = "결제 타입은 필수입니다.")
+    private PayType payType; // 결제 타입 : 카드/현금/포인트
+
+    @NotNull(message = "결제 금액은 필수입니다.")
+    @Positive(message = "결제 금액은 양수여야 합니다.")
+    private Long amount; // 가격 정보
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    private String orderName;
+
+    @NotNull(message = "예약 ID는 필수입니다.")
+    private UUID reservationId;
+
+    @Builder.Default
+    private PaymentStatus status = PaymentStatus.REQUESTED;
+
+
+    private UUID couponId;
+
+    private String yourSuccessUrl; // 성공 시 리다이렉트 될 URL
+    private String yourFailUrl; // 실패 시 리다이렉트 될 URL
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentResponseDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentResponseDto.java
@@ -1,0 +1,39 @@
+package com.tk.gg.payment.application.dto;
+
+import com.tk.gg.payment.domain.model.Payment;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+public class PaymentResponseDto {
+    private UUID paymentId;
+    private String payType; // 결제 타입 - 카드/현금/포인트
+    private Long amount; // 가격 정보
+    private String customerEmail; // 고객 이메일
+    private String customerName; // 고객 이름
+    private String successUrl; // 성공 시 리다이렉트 될 URL
+    private String failUrl; // 실패 시 리다이렉트 될 URL
+    private String orderName;
+    private String failReason; // 실패 이유
+    private boolean cancelYN; // 취소 YN
+    private String cancelReason; // 취소 이유
+    private String createdAt; // 결제가 이루어진 시간
+
+    public static PaymentResponseDto of(Payment payment, String customerEmail, String customerName, String successUrl, String failUrl, String orderName) {
+        return PaymentResponseDto.builder()
+                .paymentId(payment.getPaymentId())
+                .payType(payment.getPayType().toString())
+                .amount(payment.getAmount())
+                .orderName(orderName)
+                .customerEmail(customerEmail)
+                .customerName(customerName)
+                .successUrl(successUrl)
+                .failUrl(failUrl)
+                .build();
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentSuccessCardDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentSuccessCardDto.java
@@ -1,0 +1,17 @@
+package com.tk.gg.payment.application.dto;
+
+import lombok.Data;
+
+@Data
+public class PaymentSuccessCardDto {
+    String company; // 회사명
+    String number; // 카드번호
+    String installmentPlanMonths; // 할부 개월
+    String isInterestFree;
+    String approveNo; // 승인번호
+    String useCardPoint; // 카드 포인트 사용 여부
+    String cardType; // 카드 타입
+    String ownerType; // 소유자 타입
+    String acquireStatus; // 승인 상태
+    String receiptUrl; // 영수증 URL
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentSuccessDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentSuccessDto.java
@@ -1,0 +1,37 @@
+package com.tk.gg.payment.application.dto;
+
+import com.tk.gg.payment.domain.model.Payment;
+import lombok.Data;
+
+@Data
+public class PaymentSuccessDto {
+    String mid; // 가맹점 Id -> tosspayments
+    String version; // Payment 객체 응답 버전
+    String paymentKey;
+    String orderId;
+    String orderName;
+    String currency; // "KRW"
+    String method; // 결제 수단
+    String totalAmount;
+    String balanceAmount;
+    String suppliedAmount;
+    String vat; // 부가가치세
+    String status; // 결제 처리 상태
+    String requestedAt;
+    String approvedAt;
+    String useEscrow; // false
+    String cultureExpense; // false
+    PaymentSuccessCardDto card; // 결제 카드 정보 (아래 자세한 정보 있음)
+    String type; // 결제 타입 정보 (NOMAL / BILLING / CONNECTPAY)
+
+    public static PaymentSuccessDto of(Payment payment) {
+        PaymentSuccessDto dto = new PaymentSuccessDto();
+        dto.setPaymentKey(payment.getPaymentKey());
+        dto.setOrderId(payment.getPaymentId().toString());
+        dto.setTotalAmount(payment.getAmount().toString());
+        dto.setStatus(payment.isPaySuccessYN() ? "DONE" : "READY");
+        // 나머지 필드들은 Payment 객체에서 가져올 수 있는 정보로 설정
+        // 일부 정보는 Toss Payments API 응답에서 가져와야 할 수 있습니다
+        return dto;
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/service/PaymentService.java
@@ -1,0 +1,118 @@
+package com.tk.gg.payment.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.payment.application.client.UserService;
+import com.tk.gg.payment.application.dto.PaymentFailDto;
+import com.tk.gg.payment.application.dto.PaymentRequestDto;
+import com.tk.gg.payment.application.dto.PaymentSuccessDto;
+import com.tk.gg.payment.domain.model.Payment;
+import com.tk.gg.payment.domain.service.PaymentDomainService;
+import com.tk.gg.payment.infrastructure.config.TossPaymentConfig;
+import com.tk.gg.payment.infrastructure.repository.PaymentRepository;
+import com.tk.gg.security.user.AuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentService {
+
+    private final UserService userService;
+    private final PaymentDomainService paymentDomainService;
+    private final PaymentRepository paymentRepository;
+    private final TossPaymentConfig tossPaymentConfig;
+
+
+    @Transactional
+    public Payment requestTossPayment(PaymentRequestDto requestDto, AuthUserInfo authUserInfo) {
+        boolean userExists = userService.isUserExistsByEmail(authUserInfo.getEmail());
+        if (!userExists) {
+            throw new GlowGlowException(GlowGlowError.USER_NO_EXIST);
+        }
+
+        Payment payment = paymentDomainService.createPayment(requestDto, authUserInfo);
+        return paymentRepository.save(payment);
+    }
+
+    @Transactional
+    public PaymentSuccessDto tossPaymentSuccess(String paymentKey, String orderId, Long amount) {
+        Payment payment = findPaymentByOrderId(orderId); // orderId == PaymentId
+
+        paymentDomainService.verifyPaymentAmount(payment, amount);  // 요청 가격과 결제된 금액 비교
+
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = getHeaders();
+        //JSONObject params = new JSONObject();
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode params = objectMapper.createObjectNode();
+        params.put("orderId", orderId);
+        params.put("amount", amount);
+
+        PaymentSuccessDto result = null;
+            // 최종 결제 승인 요청 URL : config에서 작성한 https://api.tosspayments.com/v1/payments/ + paymentKey
+            result = restTemplate.postForObject(TossPaymentConfig.URL + paymentKey,
+                    new HttpEntity<>(params,headers),
+                    PaymentSuccessDto.class);
+            // restTemplate.postForObject() -> Post 요청을 보내고 객체로 결과를 받는다.
+
+        paymentDomainService.completePayment(payment, paymentKey, result.getApprovedAt());
+
+        // 결제 정보 저장
+        paymentRepository.save(payment);
+        return result;
+    }
+
+    @Transactional
+    public PaymentFailDto tossPaymentFail(String code, String message, String orderId) {
+        Payment payment = findPaymentByOrderId(orderId);
+
+        paymentDomainService.failPayment(payment, message);
+        paymentRepository.save(payment);
+
+        return PaymentFailDto.builder()
+                .errorCode(code)
+                .errorMessage(message)
+                .orderId(orderId)
+                .build();
+    }
+
+
+    private HttpHeaders getHeaders(){ // 요청 헤더에 꼭 Authorization 넣어줘야 함
+        // 시크릿 키를 base64로 인코딩 한 값을 넣음
+        HttpHeaders headers = new HttpHeaders();
+        String encodedAuthKey = new String(
+                Base64.getEncoder()
+                        .encode((tossPaymentConfig.getSecretKey() + ":")
+                                .getBytes(StandardCharsets.UTF_8)));
+
+        // Basic Authorization 인가 코드를 보낼 때 시크릿 키를 Base64를 사용하여 인코딩하여 보내게 되는데,
+        // 이 때, {시크릿 키 + ":"} 조합으로 인코딩해야한다.
+        headers.set("Authorization", "Basic " + encodedAuthKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        return headers;
+    }
+
+
+    // Payment 존재 여부 확인
+    private Payment findPaymentByOrderId(String orderId) {
+        return paymentRepository.findByPaymentId(UUID.fromString(orderId))
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.PAYMENT_NO_EXIST));
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/model/Payment.java
@@ -1,0 +1,94 @@
+package com.tk.gg.payment.domain.model;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import com.tk.gg.payment.application.dto.PaymentRequestDto;
+import com.tk.gg.payment.domain.type.PayType;
+import com.tk.gg.payment.domain.type.PaymentStatus;
+import com.tk.gg.security.user.AuthUserInfo;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "payment_id", nullable = false, updatable = false)
+    private UUID paymentId; // 결제 ID
+
+    @Column(name = "pay_type",nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PayType payType; // 결제 방식
+
+    @Column(name = "amount", nullable = false)
+    private Long amount; // 결제 금액
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId; // 사용자 ID
+
+    @Column(name = "reservation_id", nullable = false)
+    private UUID reservationId; // 예약 ID
+
+    @Column(name = "coupon_id")
+    private UUID couponId; // 쿠폰 ID
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt; // 결제 완료 시간
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus status; // 결제 상태
+
+    @Column(name = "order_name", nullable = false)
+    private String orderName; // 결제명 PG
+
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+
+    @Setter
+    private boolean paySuccessYN;
+
+    @Column
+    @Setter
+    private String paymentKey;
+
+    @Column
+    @Setter
+    private String failReason;
+
+    @Column
+    private boolean cancelYN;
+
+    public void changeStatusCompleted() {
+        this.status = PaymentStatus.COMPLETED;
+    }
+
+    public void changeStatusFailed() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void updatePaidAt(String approvedAt) {
+        this.paidAt = OffsetDateTime.parse(approvedAt).toLocalDateTime();
+    }
+
+
+    @Builder(builderClassName = "CreatePaymentBuilder", builderMethodName = "CreatePaymentBuilder")
+    public Payment(PaymentRequestDto requestDto, AuthUserInfo authUserInfo) {
+        this.userId = authUserInfo.getId();
+        this.createdBy = String.valueOf(authUserInfo.getId());
+        this.payType = requestDto.getPayType();
+        this.amount = requestDto.getAmount();
+        this.reservationId = requestDto.getReservationId();
+        this.couponId = requestDto.getCouponId();
+        this.status = requestDto.getStatus();
+        this.orderName = requestDto.getOrderName();
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/domain/service/PaymentDomainService.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/service/PaymentDomainService.java
@@ -1,0 +1,40 @@
+package com.tk.gg.payment.domain.service;
+
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.payment.application.dto.PaymentRequestDto;
+import com.tk.gg.payment.domain.model.Payment;
+import com.tk.gg.security.user.AuthUserInfo;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentDomainService {
+    public Payment createPayment(PaymentRequestDto requestDto, AuthUserInfo authUserInfo) {
+        return Payment.CreatePaymentBuilder()
+                .authUserInfo(authUserInfo)
+                .requestDto(requestDto)
+                .build();
+
+    }
+
+
+    public void verifyPaymentAmount(Payment payment, Long amount) {
+        if(!payment.getAmount().equals(amount)) {
+            throw new GlowGlowException(GlowGlowError.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    public void completePayment(Payment payment, String paymentKey, String approvedAt) {
+        payment.setPaymentKey(paymentKey);
+        payment.setPaySuccessYN(true);
+        payment.changeStatusCompleted();
+        payment.updatePaidAt(approvedAt);
+    }
+
+    public void failPayment(Payment payment, String message) {
+        payment.setPaySuccessYN(false);
+        payment.setFailReason(message);
+        payment.changeStatusFailed();
+    }
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/domain/type/PayType.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/type/PayType.java
@@ -1,0 +1,17 @@
+package com.tk.gg.payment.domain.type;
+
+public enum PayType {
+    CARD("카드"),
+    CASH("현금"),
+    POINT("포인트");
+
+    private String description;
+
+    PayType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/domain/type/PaymentStatus.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/type/PaymentStatus.java
@@ -1,0 +1,17 @@
+package com.tk.gg.payment.domain.type;
+
+public enum PaymentStatus {
+    REQUESTED("요청됨"),
+    COMPLETED("완료"),
+    FAILED("실패");
+
+    private final String description;
+
+    PaymentStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/client/UserFeignClient.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/client/UserFeignClient.java
@@ -1,0 +1,12 @@
+package com.tk.gg.payment.infrastructure.client;
+
+import com.tk.gg.common.response.GlobalResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserFeignClient {
+    @GetMapping("/api/feign/user/exist/{email}")
+    GlobalResponse<Boolean> findByEmail(@PathVariable("email") String email);
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/config/SecurityConfig.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.tk.gg.payment.infrastructure.config;
+
+import com.tk.gg.security.hooks.SecurityRequestMatcher;
+import com.tk.gg.security.hooks.SecurityRequestMatcherChain;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityRequestMatcherChain securityRequestMatcherChain() {
+        SecurityRequestMatcherChain matcherChain = new SecurityRequestMatcherChain();
+        matcherChain
+                .add(SecurityRequestMatcher.permitAllOf("/api/auth/**"))
+                //.add(SecurityRequestMatcher.permitAllOf("/api/payments"))
+        ;
+
+        return matcherChain;
+    }
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/config/TossPaymentConfig.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/config/TossPaymentConfig.java
@@ -1,0 +1,25 @@
+package com.tk.gg.payment.infrastructure.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class TossPaymentConfig {
+
+    @Value("${payment.toss.client-key}")
+    private String clientKey;
+
+    @Value("${payment.toss.secret-key}")
+    private String secretKey;
+
+    @Value("${payment.toss.success_url}")
+    private String successUrl;
+
+    @Value("${payment.toss.fail_url}")
+    private String failUrl;
+
+    // 토스페이먼츠에 결제 승인 요청을 보낼 URL
+    public static final String URL = "https://api.tosspayments.com/v1/payments/";
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/controller/PaymentController.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/controller/PaymentController.java
@@ -1,0 +1,69 @@
+package com.tk.gg.payment.infrastructure.controller;//package com.tk.gg.payment.infrastructure.controller;
+
+import com.tk.gg.payment.application.service.PaymentService;
+import com.tk.gg.payment.application.dto.PaymentFailDto;
+import com.tk.gg.payment.application.dto.PaymentRequestDto;
+import com.tk.gg.payment.application.dto.PaymentResponseDto;
+import com.tk.gg.payment.application.dto.PaymentSuccessDto;
+import com.tk.gg.payment.domain.model.Payment;
+import com.tk.gg.payment.infrastructure.config.TossPaymentConfig;
+import com.tk.gg.security.user.AuthUser;
+import com.tk.gg.security.user.AuthUserInfo;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+@Slf4j
+public class PaymentController {
+
+    private final TossPaymentConfig tossPaymentConfig;
+    private final PaymentService paymentService;
+
+    @PostMapping("/toss")
+    public ResponseEntity requestTossPayment(
+            @AuthUser AuthUserInfo authUserInfo,
+            @RequestBody @Valid PaymentRequestDto requestDto
+            ) {
+        Payment payment = paymentService.requestTossPayment(requestDto, authUserInfo);
+
+        String successUrl = requestDto.getYourSuccessUrl() != null ? requestDto.getYourSuccessUrl() : tossPaymentConfig.getSuccessUrl();
+        String failUrl = requestDto.getYourFailUrl() != null ? requestDto.getYourFailUrl() : tossPaymentConfig.getFailUrl();
+
+        PaymentResponseDto responseDto = PaymentResponseDto.of(
+                payment,
+                authUserInfo.getEmail(),
+                requestDto.getOrderName(),
+                authUserInfo.getUsername(),
+                successUrl,
+                failUrl
+        );
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/toss/success")
+    public ResponseEntity tossPaymentSuccess(
+            @RequestParam String paymentKey,
+            @RequestParam String orderId,
+            @RequestParam Long amount
+    ){
+        PaymentSuccessDto responseDto = paymentService.tossPaymentSuccess(paymentKey,orderId,amount);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @GetMapping("/toss/fail")
+    public ResponseEntity tossPaymentFail(
+            @RequestParam String code,
+            @RequestParam String message,
+            @RequestParam String orderId
+    ){
+        PaymentFailDto responseDto = paymentService.tossPaymentFail(code,message,orderId);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/repository/PaymentRepository.java
@@ -1,0 +1,14 @@
+package com.tk.gg.payment.infrastructure.repository;
+
+import com.tk.gg.payment.domain.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+    Optional<Payment> findByPaymentIdAndIsDeletedFalse(UUID paymentId);
+    default Optional<Payment> findByPaymentId(UUID paymentId) {
+        return findByPaymentIdAndIsDeletedFalse(paymentId);
+    }
+}

--- a/payment/src/main/resources/static/paymentprepare.html
+++ b/payment/src/main/resources/static/paymentprepare.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+    <title>결제하기</title>
+    <script src="https://js.tosspayments.com/v1/payment"></script>
+    <style>
+        body {
+            font-family: 'Arial', sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f4f4f4;
+        }
+        h2 {
+            color: #2c3e50;
+            text-align: center;
+        }
+        .payment-form {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            color: #34495e;
+        }
+        input[type="text"], input[type="number"], select {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #3498db;
+            color: white;
+            padding: 10px 15px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            width: 100%;
+            font-size: 16px;
+        }
+        button:hover {
+            background-color: #2980b9;
+        }
+    </style>
+</head>
+<body>
+<section class="payment-form">
+    <h2>결제하기</h2>
+    <div class="form-group">
+        <label for="token">인증 토큰:</label>
+        <input type="text" id="token" placeholder="Bearer 토큰을 입력하세요" required />
+    </div>
+    <div class="form-group">
+        <label for="payType">결제 타입:</label>
+        <select id="payType" required>
+            <option value="">선택하세요</option>
+            <option value="CARD">카드</option>
+            <option value="CASH">현금</option>
+            <option value="POINT">포인트</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <label for="amount">결제 금액:</label>
+        <input type="number" id="amount" placeholder="금액을 입력하세요" required />
+    </div>
+    <div class="form-group">
+        <label for="orderName">상품명:</label>
+        <input type="text" id="orderName" placeholder="상품명을 입력하세요" required />
+    </div>
+    <div class="form-group">
+        <label for="reservationId">예약 ID:</label>
+        <input type="text" id="reservationId" placeholder="예약 ID를 입력하세요" required />
+    </div>
+    <div class="form-group">
+        <label for="couponId">쿠폰 ID (선택):</label>
+        <input type="text" id="couponId" placeholder="쿠폰 ID를 입력하세요" />
+    </div>
+    <button id="payment-button">결제하기</button>
+</section>
+
+<script>
+    var button = document.getElementById('payment-button');
+    button.addEventListener('click', function () {
+        var token = document.getElementById('token').value;
+        var payType = document.getElementById('payType').value;
+        var amount = parseInt(document.getElementById('amount').value, 10);
+        var orderName = document.getElementById('orderName').value;
+        var reservationId = document.getElementById('reservationId').value;
+        var couponId = document.getElementById('couponId').value || null;
+
+        // 입력 유효성 검사
+        if (!token || !payType || isNaN(amount) || amount <= 0 || !orderName || !reservationId) {
+            alert('모든 필수 필드를 올바르게 입력해주세요.');
+            return;
+        }
+
+        // 서버에 결제 요청 전송
+        fetch('/api/payments/toss', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
+            },
+            body: JSON.stringify({
+                payType: payType,
+                amount: amount,
+                orderName: orderName,
+                reservationId: reservationId,
+                couponId: couponId
+            })
+        })
+            .then(response => {
+                if (!response.ok) {
+                    return response.text().then(text => {
+                        throw new Error(text || '서버 응답이 올바르지 않습니다.');
+                    });
+                }
+                return response.json();
+            })
+            .then(data => {
+                var clientKey = 'test_ck_6bJXmgo28eE5Y2gdPLJj8LAnGKWx';
+                var tossPayments = TossPayments(clientKey);
+
+                var paymentAmount = parseInt(data.amount, 10);
+                if (isNaN(paymentAmount) || paymentAmount <= 0) {
+                    throw new Error('올바르지 않은 결제 금액입니다.');
+                }
+
+
+
+                tossPayments.requestPayment(data.payType, {
+                    amount: paymentAmount, // 결제 금액
+                    orderId: data.paymentId, // 주문 번호
+                    orderName: orderName, // 결제 상품
+                    //customerName: data.customerName,
+                    //customerEmail: data.customerEmail,
+                    successUrl: "http://localhost:19096/api/payments/toss/success",
+                    failUrl: "http://localhost:19096/api/payments/toss/fail",
+                });
+
+                console.log("@@@"+data.customerName, amount, data.paymentId, orderName);
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('결제 요청 중 오류가 발생했습니다: ' + error.message);
+            });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #78 
## 📝 작업 내용 요약

- 결제를 위한 TossPayment 연동
- 결제 창을 띄우기 위한 html 추가

### 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/2220f772-2891-41c6-af08-b43d983351e4)

- 토스페이먼츠 결제창을 띄우기 위하여 결제준비 html 코드를 추가했습니다.
- POSTMAN으로 테스트하듯이 값을 넣고 요청을 하면 /api/payments/toss로 POST요청을 보내게 됩니다.
- 결제가 완료되면 /toss/success로 실패하면 /toss/fail로 리다이렉트하며, 실제 결제가 아닌 테스트결제이기 때문에 결제가 실패하는 것을 확인하려면 따로 실패(fail) api를 호출해야합니다.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
