### PR TITLE
[FIX] S3 Bean 조건부 활성화

### DIFF
--- a/GlowGrow-common/build.gradle
+++ b/GlowGrow-common/build.gradle
@@ -28,8 +28,8 @@ dependencies
             runtimeOnly 'org.postgresql:postgresql'
 
             // S3
-            implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.0")
-            implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+            compileOnly platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.0")
+            compileOnly 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
             // JPA - 공통 의존성으로 서브모듈에도 전달
             api 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/s3/S3UploadService.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/s3/S3UploadService.java
@@ -2,6 +2,7 @@ package com.tk.gg.common.s3;
 
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -13,6 +14,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import java.io.InputStream;
 
 @Service
+@ConditionalOnProperty(name = "app.s3.enabled", havingValue = "true", matchIfMissing = false)
 public class S3UploadService implements UploadService {
 
     private final S3Client s3Client;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #105 

## 📝 작업 내용 요약

- Common 모듈은 대부분의 모듈에서 의존받고있기 때문에 S3를 사용하는 모듈만 Bean을 활성화 할 수 있도록 구현했습니다.

### 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/8ae0fc58-432d-46bd-ac65-af19d154cd25)
- s3를 사용하지 않는 모듈에서는 위와 같이 yml 설정을 추가하여 S3 Bean을 비활성화합니다.

![image](https://github.com/user-attachments/assets/117c02df-03f5-4aa1-8826-4bc56403cda1)
- s3를 사용하는 모듈에서는 위와 같이 yml 설정을 추가하여 S3 Bean을 받을 수 있도록 활성화합니다.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
