### PR TITLE
[BUG] 사용자 결제 취소 데이터 다중 -> 단일 결과 반환 수정

### DIFF
--- a/payment/src/main/java/com/tk/gg/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/service/PaymentService.java
@@ -126,7 +126,7 @@ public class PaymentService {
 
     @Transactional
     public void tossPaymentUserCancel(String code, String message, AuthUserInfo authUserInfo) {
-        Payment payment = paymentRepository.findByUserId(authUserInfo.getId())
+        Payment payment = paymentRepository.findLatestByUserId(authUserInfo.getId())
                         .orElseThrow(() -> new GlowGlowException(GlowGlowError.PAYMENT_NO_EXIST));
 
         paymentDomainService.cancelPayment(payment, message);

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/repository/PaymentRepository.java
@@ -1,7 +1,9 @@
 package com.tk.gg.payment.infrastructure.repository;
 
 import com.tk.gg.payment.domain.model.Payment;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -17,6 +19,8 @@ public interface PaymentRepository extends JpaRepository<Payment, UUID> {
         return findByPaymentKeyAndUserId(paymentKey, userId);
     }
 
-    Optional<Payment> findByUserId(Long userId);
+    @Query(value = "SELECT * FROM payment WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1", nativeQuery = true)
+    Optional<Payment> findLatestByUserId(@Param("userId") Long userId);
+
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #107 

## 📝 작업 내용 요약

- 사용자 결제 취소 시 다중결과 반환 -> 단일 결과 반환으로 수정

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
