### PR TITLE
[FEAT] 결제 : 서버 사이드 렌더링으로 변경

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation project(':GlowGrow-common')
     implementation project(':GlowGrow-security')
 
-    //implementation 'net.minidev:json-smart:2.4.9'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentRequestDto.java
+++ b/payment/src/main/java/com/tk/gg/payment/application/dto/PaymentRequestDto.java
@@ -3,6 +3,7 @@ package com.tk.gg.payment.application.dto;
 import com.tk.gg.payment.domain.model.Payment;
 import com.tk.gg.payment.domain.type.PayType;
 import com.tk.gg.payment.domain.type.PaymentStatus;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -29,6 +30,10 @@ public class PaymentRequestDto {
 
     @NotNull(message = "예약 ID는 필수입니다.")
     private UUID reservationId;
+
+    @Email
+    @NotNull(message = "서비스 제공자의 이메일은 필수입니다.")
+    private String customerEmail;
 
     @Builder.Default
     private PaymentStatus status = PaymentStatus.REQUESTED;

--- a/payment/src/main/java/com/tk/gg/payment/domain/model/Payment.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/model/Payment.java
@@ -57,6 +57,9 @@ public class Payment extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted = false;
 
+    @Column(name = "customer_email",nullable = false)
+    private String customerEmail;
+
     @Setter
     private boolean paySuccessYN;
 
@@ -106,5 +109,6 @@ public class Payment extends BaseEntity {
         this.couponId = requestDto.getCouponId();
         this.status = requestDto.getStatus();
         this.orderName = requestDto.getOrderName();
+        this.customerEmail = requestDto.getCustomerEmail();
     }
 }

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/config/SecurityConfig.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/config/SecurityConfig.java
@@ -10,11 +10,11 @@ public class SecurityConfig {
     @Bean
     public SecurityRequestMatcherChain securityRequestMatcherChain() {
         SecurityRequestMatcherChain matcherChain = new SecurityRequestMatcherChain();
-        matcherChain
-                .add(SecurityRequestMatcher.permitAllOf("/api/auth/**"))
-                //.add(SecurityRequestMatcher.permitAllOf("/api/payments"))
-        ;
-
+        matcherChain.addAll(
+                SecurityRequestMatcher.permitAllOf("/api/auth/**"),
+                SecurityRequestMatcher.permitAllOf("/api/payments/client-key"),
+                SecurityRequestMatcher.permitAllOf("/api/payments/prepare")
+        );
         return matcherChain;
     }
 }

--- a/payment/src/main/resources/logback.xml
+++ b/payment/src/main/resources/logback.xml
@@ -1,18 +1,35 @@
 <configuration>
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>http://13.124.27.13:3100/loki/api/v1/push</url>
-        </http>
-        <format>
-            <label>
-                <pattern>app=glowgrow,service=payment-service,level=%level</pattern>
-            </label>
-            <message>
-                <pattern>t=%d{yyyy-MM-dd HH:mm:ss.SSS} l=%level c=%logger{20} t=%thread | %msg %ex</pattern>
-            </message>
-        </format>
-    </appender>
-    <root level="DEBUG">
-        <appender-ref ref="LOKI" />
-    </root>
+    <!-- 프로필이 prod일 때 로키로 로그 전송 -->
+    <springProfile name="prod">
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>http://13.124.27.13:3100/loki/api/v1/push</url>
+            </http>
+            <format>
+                <label>
+                    <pattern>app=glowgrow,service=payment-service,level=%level</pattern>
+                </label>
+                <message>
+                    <pattern>t=%d{yyyy-MM-dd HH:mm:ss.SSS} l=%level c=%logger{20} t=%thread | %msg %ex</pattern>
+                </message>
+            </format>
+        </appender>
+
+        <root level="DEBUG">
+            <appender-ref ref="LOKI" />
+        </root>
+    </springProfile>
+
+    <!-- 로컬 개발 환경에서 로그를 콘솔에 출력 -->
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 </configuration>

--- a/payment/src/main/resources/templates/payment-prepare.html
+++ b/payment/src/main/resources/templates/payment-prepare.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="utf-8" />
-    <title>결제하기</title>
+    <title>결제 준비</title>
     <script src="https://js.tosspayments.com/v1/payment"></script>
     <style>
         body {
@@ -62,6 +62,10 @@
         <input type="text" id="token" placeholder="Bearer 토큰을 입력하세요" required />
     </div>
     <div class="form-group">
+        <label for="customerEmail">서비스 이용자 이메일:</label>
+        <input type="email" id="customerEmail" placeholder="이메일을 입력하세요" required />
+    </div>
+    <div class="form-group">
         <label for="payType">결제 타입:</label>
         <select id="payType" required>
             <option value="">선택하세요</option>
@@ -91,6 +95,23 @@
 
 <script>
     var button = document.getElementById('payment-button');
+
+    // 페이지 로드 시 서버에서 clientKey를 가져오는 함수
+    function getClientKey() {
+        return fetch('/api/payments/client-key', {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch client key');
+                }
+                return response.text();
+            });
+    }
+
     button.addEventListener('click', function () {
         var token = document.getElementById('token').value;
         var payType = document.getElementById('payType').value;
@@ -98,10 +119,19 @@
         var orderName = document.getElementById('orderName').value;
         var reservationId = document.getElementById('reservationId').value;
         var couponId = document.getElementById('couponId').value || null;
+        var customerEmail = document.getElementById('customerEmail').value;
+
+        // 이메일 형식 검사를 위한 정규표현식
+        var emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
         // 입력 유효성 검사
-        if (!token || !payType || isNaN(amount) || amount <= 0 || !orderName || !reservationId) {
+        if (!token || !payType || isNaN(amount) || amount <= 0 || !orderName || !reservationId || !customerEmail) {
             alert('모든 필수 필드를 올바르게 입력해주세요.');
+            return;
+        }
+
+        if (!emailRegex.test(customerEmail)) {
+            alert('유효한 이메일 주소를 입력해주세요.');
             return;
         }
 
@@ -117,7 +147,8 @@
                 amount: amount,
                 orderName: orderName,
                 reservationId: reservationId,
-                couponId: couponId
+                couponId: couponId,
+                customerEmail: customerEmail
             })
         })
             .then(response => {
@@ -126,40 +157,58 @@
                         throw new Error(text || '서버 응답이 올바르지 않습니다.');
                     });
                 }
-                return response.json();
+                return response.json();  // JSON 응답을 반환
             })
             .then(data => {
-                var clientKey = 'test_ck_6bJXmgo28eE5Y2gdPLJj8LAnGKWx';
-                var tossPayments = TossPayments(clientKey);
+                console.log('결제 요청 응답 데이터:', data);  // 응답 데이터를 로그로 출력
 
-                var paymentAmount = parseInt(data.amount, 10);
-                if (isNaN(paymentAmount) || paymentAmount <= 0) {
-                    throw new Error('올바르지 않은 결제 금액입니다.');
-                }
+                return getClientKey()  // 서버에서 clientKey를 가져옴
+                    .then(clientKey => {
+                        var tossPayments = TossPayments(clientKey);
 
+                        var paymentAmount = parseInt(data.amount, 10); // data.amount로 결제 금액을 설정
+                        if (isNaN(paymentAmount) || paymentAmount <= 0) {
+                            throw new Error('올바르지 않은 결제 금액입니다.');
+                        }
 
+                        // window.location.hostname을 사용하여 동적으로 URL 설정
+                        var hostname = window.location.hostname;
+                        var successUrl, failUrl;
 
-                tossPayments.requestPayment(data.payType, {
-                    amount: paymentAmount,
-                    orderId: data.paymentId,
-                    orderName: orderName,
-                    successUrl: "http://localhost:19096/api/payments/toss/success",
-                    failUrl: "http://localhost:19096/api/payments/toss/fail",
-                }).catch(function (error) {
-                    if (error.code === "USER_CANCEL") {
-                        // 결제 고객이 결제창을 닫았을 때 에러 처리
-                        console.log("사용자가 결제를 취소했습니다.");
-                        fetch("http://localhost:19096/api/payments/toss/fail-cancel?code=" + error.code + "&message=" + error.message, {
-                            method: 'GET',
-                            headers: {
-                                'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
+                        if (hostname === 'localhost') {
+                            // 로컬 개발 환경 URL
+                            successUrl = "http://localhost:19096/api/payments/toss/success";
+                            failUrl = "http://localhost:19096/api/payments/toss/fail";
+                        } else {
+                            // prod 환경 URL
+                            successUrl = "http://13.209.24.74:19091/api/payments/toss/success";
+                            failUrl = "http://13.209.24.74:19091/api/payments/toss/fail";
+                        }
+
+                        // 결제 요청
+                        tossPayments.requestPayment(data.payType, {
+                            amount: paymentAmount,
+                            orderId: data.paymentId,  // reservationId 사용
+                            orderName: orderName,
+                            successUrl: successUrl,
+                            failUrl: failUrl,
+                        }).catch(function (error) {
+                            if (error.code === "USER_CANCEL") {
+                                // 결제 고객이 결제창을 닫았을 때 에러 처리
+                                console.log("사용자가 결제를 취소했습니다.");
+                                fetch(failUrl +"-cancel?code=" + error.code + "&message=" + error.message, {
+                                    method: 'GET',
+                                    headers: {
+                                        'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
+                                    }
+                                });
                             }
                         });
-                    }
-                });
-
+                    });
             })
-
+            .catch(error => {
+                console.error('결제 요청 중 오류:', error);
+            });
     });
 </script>
 </body>

--- a/payment/src/main/resources/templates/payment-success.html
+++ b/payment/src/main/resources/templates/payment-success.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>결제 성공</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f8f9fa;
+        }
+        .payment-success-card {
+            max-width: 500px;
+            margin: 50px auto;
+            border-radius: 15px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        .success-icon {
+            font-size: 48px;
+            color: #28a745;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="card payment-success-card">
+        <div class="card-body text-center">
+            <h1 class="card-title mb-4">결제 성공</h1>
+            <p class="success-icon">✅</p>
+            <p class="lead">결제가 성공적으로 완료되었습니다!</p>
+            <hr>
+            <div class="text-start">
+                <p><strong>결제 ID:</strong> <span th:text="${payment.orderId}"></span></p>
+                <p><strong>결제 Key:</strong> <span th:text="${payment.getPaymentKey()}"></span></p>
+                <p><strong>결제 금액:</strong> <span th:text="${#numbers.formatDecimal(payment.totalAmount, 0, 'COMMA', 0, 'POINT')}">0</span>원</p>
+                <p><strong>결제 방법:</strong> <span th:text="${payment.method}"></span></p>
+                <p><strong>결제 승인 시간:</strong> <span th:text="${payment.approvedAt}"></span></p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/post/src/main/resources/logback.xml
+++ b/post/src/main/resources/logback.xml
@@ -1,18 +1,35 @@
 <configuration>
-    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>http://13.124.27.13:3100/loki/api/v1/push</url>
-        </http>
-        <format>
-            <label>
-                <pattern>app=glowgrow,service=post-service,level=%level</pattern>
-            </label>
-            <message>
-                <pattern>t=%d{yyyy-MM-dd HH:mm:ss.SSS} l=%level c=%logger{20} t=%thread | %msg %ex</pattern>
-            </message>
-        </format>
-    </appender>
-    <root level="DEBUG">
-        <appender-ref ref="LOKI" />
-    </root>
+    <!-- 프로필이 prod일 때 로키로 로그 전송 -->
+    <springProfile name="prod">
+        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+            <http>
+                <url>http://13.124.27.13:3100/loki/api/v1/push</url>
+            </http>
+            <format>
+                <label>
+                    <pattern>app=glowgrow,service=post-service,level=%level</pattern>
+                </label>
+                <message>
+                    <pattern>t=%d{yyyy-MM-dd HH:mm:ss.SSS} l=%level c=%logger{20} t=%thread | %msg %ex</pattern>
+                </message>
+            </format>
+        </appender>
+
+        <root level="DEBUG">
+            <appender-ref ref="LOKI" />
+        </root>
+    </springProfile>
+
+    <!-- 로컬 개발 환경에서 로그를 콘솔에 출력 -->
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #129 

## 📝 작업 내용 요약

- 결제 준비 창에 직접 접근하는 대신 API 호출을 통해 서버 사이드 렌더링 방식으로 수정했습니다.
- 결제 완료 HTML을 추가했습니다.
- 결제 시 서비스 이용자 이메일을 받도록 추가했습니다.

### 📸 스크린샷 (선택)

- 결제 성공 HTML
![image](https://github.com/user-attachments/assets/daab369b-7925-418a-b9a6-d026e0f2ca3c)


## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
