### PR TITLE
[FEAT] 예약 전체 조회 시 검색 기능 추가 및 수정

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/kafka/payment/PaymentForReservationEventDto.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/kafka/payment/PaymentForReservationEventDto.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 public record PaymentForReservationEventDto(
         UUID reservationId,
-        Long userId
+        Long customerId,
+        Long providerId,
+        Integer price
 ) {
 }

--- a/reservation/src/main/java/com/tk/gg/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/service/ReservationService.java
@@ -120,7 +120,7 @@ public class ReservationService {
                 throw new GlowGlowException(GlowGlowError.RESERVATION_NOT_DONE_FOR_PAYMENT);
             }
             paymentKafkaProducer.sendReservationToPaymentEvent(new PaymentForReservationEventDto(
-                    reservationId, userInfo.getId()
+                    reservationId, reservation.getCustomerId(),reservation.getServiceProviderId(),reservation.getPrice()
             ));
         }
 

--- a/reservation/src/main/java/com/tk/gg/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/application/service/ReservationService.java
@@ -19,6 +19,7 @@ import com.tk.gg.common.kafka.grade.GradeForReservationEventDto;
 import com.tk.gg.reservation.infrastructure.messaging.GradeKafkaProducer;
 import com.tk.gg.reservation.infrastructure.messaging.NotificationKafkaProducer;
 import com.tk.gg.reservation.infrastructure.messaging.PaymentKafkaProducer;
+import com.tk.gg.reservation.presentation.request.ReservationSearchCondition;
 import com.tk.gg.security.user.AuthUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,10 +47,9 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public Page<ReservationDto> searchReservations(
-            LocalDate startDate, LocalDate endDate,
-            ReservationStatus status, Pageable pageable, AuthUserInfo userInfo
+            ReservationSearchCondition searchCondition, Pageable pageable, AuthUserInfo userInfo
     ) {
-        return reservationDomainService.searchReservations(startDate, endDate, status, pageable, userInfo).map(ReservationDto::from);
+        return reservationDomainService.searchReservations(searchCondition, pageable, userInfo).map(ReservationDto::from);
     }
 
     @Transactional(readOnly = true)
@@ -108,19 +108,19 @@ public class ReservationService {
             throw new GlowGlowException(RESERVATION_NOT_OWNER);
         }
         // 사용자 권한 status -> 취소, 결제 요청만 가능
-        if (userInfo.getUserRole().equals(UserRole.CUSTOMER)){
-            if(!status.equals(ReservationStatus.CANCEL) && !status.equals(ReservationStatus.PAYMENT_CALL)) {
+        if (userInfo.getUserRole().equals(UserRole.CUSTOMER)) {
+            if (!status.equals(ReservationStatus.CANCEL) && !status.equals(ReservationStatus.PAYMENT_CALL)) {
                 throw new GlowGlowException(RESERVATION_FORBIDDEN_STATUS);
             }
         }
 
         // 결제 요청 시 카프카 이벤트 발행
-        if (status.equals(ReservationStatus.PAYMENT_CALL)){
-            if(!reservation.getReservationStatus().equals(ReservationStatus.DONE)){
+        if (status.equals(ReservationStatus.PAYMENT_CALL)) {
+            if (!reservation.getReservationStatus().equals(ReservationStatus.DONE)) {
                 throw new GlowGlowException(GlowGlowError.RESERVATION_NOT_DONE_FOR_PAYMENT);
             }
             paymentKafkaProducer.sendReservationToPaymentEvent(new PaymentForReservationEventDto(
-                    reservationId, reservation.getCustomerId(),reservation.getServiceProviderId(),reservation.getPrice()
+                    reservationId, reservation.getCustomerId(), reservation.getServiceProviderId(), reservation.getPrice()
             ));
         }
 

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/repository/ReservationRepositoryCustom.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/repository/ReservationRepositoryCustom.java
@@ -1,13 +1,12 @@
 package com.tk.gg.reservation.domain.repository;
 
 import com.tk.gg.reservation.domain.model.Reservation;
-import com.tk.gg.reservation.domain.type.ReservationStatus;
+import com.tk.gg.reservation.presentation.request.ReservationSearchCondition;
 import com.tk.gg.security.user.AuthUserInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
 
 public interface ReservationRepositoryCustom {
-    Page<Reservation> searchReservations(LocalDate startDate, LocalDate endDate, ReservationStatus status, Pageable pageable, AuthUserInfo userInfo);
+    Page<Reservation> searchReservations(ReservationSearchCondition searchCondition, Pageable pageable, AuthUserInfo userInfo);
 }

--- a/reservation/src/main/java/com/tk/gg/reservation/domain/service/ReservationDomainService.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/domain/service/ReservationDomainService.java
@@ -8,6 +8,7 @@ import com.tk.gg.reservation.domain.model.Reservation;
 import com.tk.gg.reservation.domain.model.TimeSlot;
 import com.tk.gg.reservation.infrastructure.repository.ReservationRepository;
 import com.tk.gg.reservation.domain.type.ReservationStatus;
+import com.tk.gg.reservation.presentation.request.ReservationSearchCondition;
 import com.tk.gg.security.user.AuthUserInfo;
 import jakarta.ws.rs.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -31,9 +32,9 @@ public class ReservationDomainService {
     private final ReservationRepository reservationRepository;
 
     public Page<Reservation> searchReservations(
-            LocalDate startDate, LocalDate endDate, ReservationStatus status,Pageable pageable, AuthUserInfo userInfo
+            ReservationSearchCondition searchCondition, Pageable pageable, AuthUserInfo userInfo
     ) {
-        return reservationRepository.searchReservations(startDate, endDate, status, pageable, userInfo);
+        return reservationRepository.searchReservations(searchCondition, pageable, userInfo);
     }
 
     public Reservation getOne(UUID id) {
@@ -50,22 +51,22 @@ public class ReservationDomainService {
     //TODO : 예약 취소, 거절 가능 날짜 검증 추가
     public void updateOne(Reservation reservation, UpdateReservationDto dto, TimeSlot timeSlot) {
         // 예약 시간을 바꿀 때 한번 더 빈 시간대인지 검증
-        if(!reservation.getTimeSlot().equals(timeSlot) && timeSlot.getIsReserved().equals(true))
+        if (!reservation.getTimeSlot().equals(timeSlot) && timeSlot.getIsReserved().equals(true))
             throw new GlowGlowException(RESERVATION_UPDATE_FAILED);
 
         reservation.update(dto, timeSlot);
     }
 
     //TODO : 예약 취소, 거절 가능 날짜 검증 추가
-    public void updateStatus(Reservation reservation  ,ReservationStatus status){
+    public void updateStatus(Reservation reservation, ReservationStatus status) {
         // 제공자 취소,거절 시 예약 가능시간테이블 정보 상태 수정
-        if (status.equals(ReservationStatus.CANCEL) || status.equals(ReservationStatus.REFUSED)){
+        if (status.equals(ReservationStatus.CANCEL) || status.equals(ReservationStatus.REFUSED)) {
             reservation.getTimeSlot().updateIsReserved(false);
         }
         reservation.updateStatus(status);
     }
 
-    public void deleteOne(Reservation reservation,String deletedBy) {
+    public void deleteOne(Reservation reservation, String deletedBy) {
         reservation.getTimeSlot().updateIsReserved(false);
         reservation.delete(deletedBy);
     }

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/ReservationController.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/ReservationController.java
@@ -6,6 +6,7 @@ import com.tk.gg.common.response.GlobalResponse;
 import com.tk.gg.reservation.application.service.ReservationService;
 import com.tk.gg.reservation.domain.type.ReservationStatus;
 import com.tk.gg.reservation.presentation.request.CreateReservationRequest;
+import com.tk.gg.reservation.presentation.request.ReservationSearchCondition;
 import com.tk.gg.reservation.presentation.request.UpdateReservationRequest;
 import com.tk.gg.reservation.presentation.request.UpdateReservationStatusRequest;
 import com.tk.gg.reservation.presentation.response.ReservationResponse;
@@ -50,19 +51,13 @@ public class ReservationController {
     @GetMapping
     @Operation(summary = "전체 조회 API", description = "예약(reservation) 목록을 조회합니다.**[ROLE: Provider,Customer,Master]**")
     public GlobalResponse<Page<ReservationResponse>> getAllReservations(
-            @Parameter(name = "startDate", description = "검색 시작 범위 날짜(yyyy-MM-dd)")
-            @RequestParam(value = "startDate", required = false)
-            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
-            @Parameter(name = "endDate", description = "검색 끝 범위 날짜(yyyy-MM-dd)")
-            @RequestParam(value = "endDate", required = false)
-            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
-            @Parameter(name = "status", description = "예약 상태", example = "ACCEPT")
-            @RequestParam(value = "status", required = false) ReservationStatus status,
-            @ParameterObject @PageableDefault(sort = {"reservationDate"}, direction = Sort.Direction.ASC) Pageable pageable,
+            @ParameterObject ReservationSearchCondition searchCondition,
+            @ParameterObject @PageableDefault(sort = {"reservationDate"}, direction = Sort.Direction.ASC)
+            Pageable pageable,
             @AuthUser AuthUserInfo userInfo
     ) {
         return ApiUtils.success(RESERVATION_RETRIEVE_SUCCESS.getMessage(),
-                reservationService.searchReservations(startDate, endDate, status, pageable, userInfo).map(ReservationResponse::from)
+                reservationService.searchReservations(searchCondition, pageable, userInfo).map(ReservationResponse::from)
         );
     }
 

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/TimeSlotController.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/controller/TimeSlotController.java
@@ -55,7 +55,7 @@ public class TimeSlotController {
             @Parameter(name = "endDate", description = "검색 끝 범위 날짜(yyyy-MM-dd)")
             @RequestParam(value = "endDate", required = false)
             @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
-            @ParameterObject @PageableDefault(sort = {"availableDate"}, direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault(sort = {"availableDate","availableTime"}, direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ApiUtils.success(
                 TIMESLOT_RETRIEVE_SUCCESS.getMessage(),

--- a/reservation/src/main/java/com/tk/gg/reservation/presentation/request/ReservationSearchCondition.java
+++ b/reservation/src/main/java/com/tk/gg/reservation/presentation/request/ReservationSearchCondition.java
@@ -1,0 +1,27 @@
+package com.tk.gg.reservation.presentation.request;
+
+import com.tk.gg.reservation.domain.type.ReservationStatus;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record ReservationSearchCondition(
+        @Parameter(name = "startDate", description = "검색 시작 범위 날짜(yyyy-MM-dd)")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+
+        @Parameter(name = "endDate", description = "검색 끝 범위 날짜(yyyy-MM-dd)")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+
+        @Parameter(name = "status", description = "예약 상태")
+        ReservationStatus status,
+
+        @Parameter(name = "customerId", description = "고객 ID")
+        Long customerId,
+
+        @Parameter(name = "providerId", description = "서비스 제공자 ID")
+        Long providerId
+) {
+}

--- a/reservation/src/test/java/com/tk/gg/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/com/tk/gg/reservation/application/service/ReservationServiceTest.java
@@ -8,6 +8,7 @@ import com.tk.gg.reservation.domain.model.TimeSlot;
 import com.tk.gg.reservation.domain.service.ReservationDomainService;
 import com.tk.gg.reservation.domain.service.TimeSlotDomainService;
 import com.tk.gg.reservation.domain.type.ReservationStatus;
+import com.tk.gg.reservation.infrastructure.messaging.NotificationKafkaProducer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,9 @@ class ReservationServiceTest {
 
     @Mock
     private TimeSlotDomainService timeSlotDomainService;
+
+    @Mock
+    private NotificationKafkaProducer notificationKafkaProducer;
 
     @InjectMocks
     private ReservationService reservationService;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- This PR closes #154 

## 📝 작업 내용 요약

- 예약에서 결제 카프카 이벤트의 DTO 를 수정함

- 예약 검색 시 고객ID, 제공자ID, 날짜, 상태 등으로 검색 가능하게 수정함
