### PR TITLE
[FEAT] 예약의 서비스 제공자에 대한 쿠폰만 사용 가능하도록 수정

### DIFF
--- a/payment/src/main/resources/templates/payment-prepare.html
+++ b/payment/src/main/resources/templates/payment-prepare.html
@@ -119,7 +119,7 @@
         loadCouponsButton.addEventListener('click', function() {
             var token = document.getElementById('token').value;
 
-            fetch('/api/payments/user-coupons', {
+            fetch(`/api/payments/user-coupons?reservationId=${document.getElementById('reservationId').value}`, {
                 method: 'GET',
                 headers: {
                     'Authorization': token.startsWith('Bearer ') ? token : 'Bearer ' + token
@@ -128,13 +128,21 @@
                 .then(response => response.json())
                 .then(coupons => {
                     couponSelect.innerHTML = '<option value="">쿠폰을 선택하세요</option>';
+
+                    // 서비스 제공자 ID 가져오기
+                    var serviceProviderId = document.getElementById('userId').value;
+
                     coupons.forEach(coupon => {
-                        var option = document.createElement('option');
-                        option.value = coupon.couponId;
-                        //option.textContent = `${coupon.discountValue}${coupon.discountType === 'PERCENTAGE' ? '%' : '원'} 할인 (${coupon.validFrom} ~ ${coupon.validUntil})`;
-                        option.textContent = `${coupon.couponcode} - ${coupon.description} - ${coupon.discountValue}${coupon.discountType === 'PERCENTAGE' ? '%' : '원'} 할인 (${coupon.validFrom} ~ ${coupon.validUntil})`;
-                        option.setAttribute('data-coupon', JSON.stringify(coupon));
-                        couponSelect.appendChild(option);
+                        var couponId = coupon.couponcode.split('-')[0]; // 쿠폰 코드에서 ID 추출
+
+                        // 서비스 제공자 ID와 비교하여 일치하는 경우만 추가
+                        if (couponId === serviceProviderId) {
+                            var option = document.createElement('option');
+                            option.value = coupon.couponId;
+                            option.textContent = `${coupon.couponcode} - ${coupon.description} - ${coupon.discountValue}${coupon.discountType === 'PERCENTAGE' ? '%' : '원'} 할인 (${coupon.validFrom} ~ ${coupon.validUntil})`;
+                            option.setAttribute('data-coupon', JSON.stringify(coupon));
+                            couponSelect.appendChild(option);
+                        }
                     });
 
                     loadCouponsButton.style.display = 'none';


### PR DESCRIPTION
Issue : #165

- #165 


## 📝 작업 내용 요약

- 예약에 대한 서비스 제공자가 발급한 쿠폰만 사용 가능하도록 수정했습니다. 예약의 서비스 제공자 ID와 쿠폰 코드를 비교하여 해당 쿠폰만 로드합니다.
- 
### 📸 스크린샷 (선택)
- 사용자 보유 쿠폰에 대한 couponCode
![image](https://github.com/user-attachments/assets/5616e442-32f8-4617-b049-8d437664c15f)

- 웹 페이지에서 내 쿠폰 불러올 때
![image](https://github.com/user-attachments/assets/db6b8dd5-1f08-4ed7-b86c-105c29d0520d)


## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
