### PR TITLE
[FEAT] 결제 요청 저장 및 알람 발송

### DIFF
--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -36,6 +36,7 @@ public enum GlowGlowError {
     PAYMENT_AMOUNT_MISMATCH(404,"PAYMENT_002","결제 금액이 일치하지 않습니다."),
     ALREADY_APPROVED(404,"PAYMENT_003","이미 승인된 결제입니다."),
     MY_PAYMENT_NOT_FOUND(404,"PAYMENT_004","내 결제정보가 존재하지 않습니다."),
+    PAYMENT_REQUEST_NOT_FOUND(404,"PAYMENT_005","결제 요청이 존재하지 않습니다."),
 
     // Refund (환불 관련 에러)
     REFUND_PROCESS_FAILED(404,"REFUND_001","환불 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),

--- a/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
+++ b/GlowGrow-common/src/main/java/com/tk/gg/common/response/exception/GlowGlowError.java
@@ -37,6 +37,7 @@ public enum GlowGlowError {
     ALREADY_APPROVED(404,"PAYMENT_003","이미 승인된 결제입니다."),
     MY_PAYMENT_NOT_FOUND(404,"PAYMENT_004","내 결제정보가 존재하지 않습니다."),
     PAYMENT_REQUEST_NOT_FOUND(404,"PAYMENT_005","결제 요청이 존재하지 않습니다."),
+    PAYMENT_NO_AUTH_PERMISSION_DENIED(403,"PAYMENT_006","결제 정보에 대한 권한이 없습니다."),
 
     // Refund (환불 관련 에러)
     REFUND_PROCESS_FAILED(404,"REFUND_001","환불 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),

--- a/payment/src/main/java/com/tk/gg/payment/domain/model/PendingPaymentRequest.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/model/PendingPaymentRequest.java
@@ -1,0 +1,58 @@
+package com.tk.gg.payment.domain.model;
+
+import com.tk.gg.common.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "pending_payment_requests")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingPaymentRequest extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private UUID reservationId;
+
+    @Column(nullable = false)
+    private Long customerId;
+
+    @Column(nullable = false)
+    private Long serviceProviderId;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public static PendingPaymentRequest create(UUID reservationId, Long customerId, Long serviceProviderId, Integer price) {
+        PendingPaymentRequest request = new PendingPaymentRequest();
+        request.reservationId = reservationId;
+        request.customerId = customerId;
+        request.serviceProviderId = serviceProviderId;
+        request.price = price;
+        request.createdAt = LocalDateTime.now();
+        return request;
+    }
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/domain/repository/PendingPaymentRequestRepository.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/repository/PendingPaymentRequestRepository.java
@@ -1,0 +1,23 @@
+package com.tk.gg.payment.domain.repository;
+
+import com.tk.gg.payment.domain.model.PendingPaymentRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PendingPaymentRequestRepository extends JpaRepository<PendingPaymentRequest, Long> {
+
+    @Query("SELECT p FROM PendingPaymentRequest p WHERE p.serviceProviderId = :serviceProviderId AND p.isDeleted = false")
+    List<PendingPaymentRequest> findActiveByServiceProviderId(@Param("serviceProviderId") Long serviceProviderId);
+
+    @Query("SELECT p FROM PendingPaymentRequest p WHERE p.reservationId = :reservationId AND p.isDeleted = false")
+    Optional<PendingPaymentRequest> findActiveByReservationId(@Param("reservationId") UUID reservationId);
+}
+
+

--- a/payment/src/main/java/com/tk/gg/payment/domain/service/PendingPaymentRequestDomainService.java
+++ b/payment/src/main/java/com/tk/gg/payment/domain/service/PendingPaymentRequestDomainService.java
@@ -1,0 +1,37 @@
+package com.tk.gg.payment.domain.service;
+
+import com.tk.gg.common.response.exception.GlowGlowError;
+import com.tk.gg.common.response.exception.GlowGlowException;
+import com.tk.gg.payment.domain.model.PendingPaymentRequest;
+import com.tk.gg.payment.domain.repository.PendingPaymentRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PendingPaymentRequestDomainService {
+
+    private final PendingPaymentRequestRepository pendingPaymentRequestRepository;
+
+    public PendingPaymentRequest createPendingPaymentRequest(UUID reservationId, Long customerId, Long serviceProviderId, Integer price) {
+        PendingPaymentRequest request = PendingPaymentRequest.create(reservationId, customerId, serviceProviderId, price);
+        return pendingPaymentRequestRepository.save(request);
+    }
+
+    public List<PendingPaymentRequest> getPendingRequestsForProvider(Long providerId) {
+        return pendingPaymentRequestRepository.findActiveByServiceProviderId(providerId);
+    }
+
+    @Transactional
+    public void softDeletePendingRequest(UUID reservationId) {
+        PendingPaymentRequest request = pendingPaymentRequestRepository.findActiveByReservationId(reservationId)
+                .orElseThrow(() -> new GlowGlowException(GlowGlowError.PAYMENT_REQUEST_NOT_FOUND));
+        request.softDelete();
+        pendingPaymentRequestRepository.save(request);
+    }
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/messaging/NotificationPaymentKafkaProducer.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/messaging/NotificationPaymentKafkaProducer.java
@@ -1,0 +1,43 @@
+package com.tk.gg.payment.infrastructure.messaging;
+
+import com.tk.gg.common.enums.NotificationType;
+import com.tk.gg.common.kafka.alarm.KafkaNotificationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j(topic = "[Payment-noti-producer]")
+@RequiredArgsConstructor
+public class NotificationPaymentKafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendPaymentSuccessToNotificationEvent(KafkaNotificationDto event){
+        log.info("결제 완료 알림 이벤트 발행 : {}", event);
+        kafkaTemplate.send("noti-send",event);
+        log.info("결제 완료 알림 이벤트 발행 완료");
+    }
+
+    public void sendPaymentFailToNotificationEvent(KafkaNotificationDto event){
+        log.info("결제 실패 완료 이벤트 발행 : {}" ,event);
+        kafkaTemplate.send("noti-send",event);
+        log.info("결제 실패 알림 이벤트 발행 완료");
+    }
+
+    public void sendPaymentNotificationToUser(Long customerId, String message, boolean isSuccess){
+        KafkaNotificationDto notificationDto = KafkaNotificationDto.builder()
+                .userId(customerId)
+                .message(message)
+                .type(NotificationType.PAYMENT.getName())
+                .build();
+
+        if (isSuccess) {
+            sendPaymentSuccessToNotificationEvent(notificationDto);
+        } else {
+            sendPaymentFailToNotificationEvent(notificationDto);
+        }
+    }
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/infrastructure/messaging/PaymentKafkaListener.java
+++ b/payment/src/main/java/com/tk/gg/payment/infrastructure/messaging/PaymentKafkaListener.java
@@ -1,0 +1,24 @@
+package com.tk.gg.payment.infrastructure.messaging;
+
+import com.tk.gg.common.kafka.payment.PaymentReservationResponseDto;
+import com.tk.gg.payment.application.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j(topic = "PAYMENT-EVENT-LISTENER")
+@RequiredArgsConstructor
+public class PaymentKafkaListener {
+
+    private final PaymentService paymentService;
+
+    @KafkaListener(topics = "reservation-payment", groupId = "payment-service")
+    public void listenPaymentRequest(PaymentReservationResponseDto event) {
+        log.info("Received payment request event: {}", event);
+        paymentService.savePendingPaymentRequest(event);
+        log.info("Payment request saved successfully");
+    }
+
+}

--- a/payment/src/main/java/com/tk/gg/payment/presentation/controller/PaymentController.java
+++ b/payment/src/main/java/com/tk/gg/payment/presentation/controller/PaymentController.java
@@ -7,6 +7,7 @@ import com.tk.gg.common.response.ResponseMessage;
 import com.tk.gg.payment.application.dto.*;
 import com.tk.gg.payment.application.service.PaymentService;
 import com.tk.gg.payment.domain.model.Payment;
+import com.tk.gg.payment.domain.model.PendingPaymentRequest;
 import com.tk.gg.payment.infrastructure.config.TossPaymentConfig;
 import com.tk.gg.security.user.AuthUser;
 import com.tk.gg.security.user.AuthUserInfo;
@@ -167,7 +168,6 @@ public class PaymentController {
     }
 
 
-
     /**
      * 사용자 보유 쿠폰 목록 조회
      * @return: 사용자 쿠폰 목록 조회 응답 DTO
@@ -178,6 +178,14 @@ public class PaymentController {
         return ResponseEntity.ok(coupons);
     }
 
-
+    /**
+     * 나에게 온 결제 요청 확인하기
+     * @return: 서비스 제공자에게 온 결제 요청 목록
+     */
+    @GetMapping("/pending-requests")
+    @ResponseBody
+    public GlobalResponse<List<PendingPaymentRequest>> getPendingPaymentRequests(@AuthUser AuthUserInfo authUserInfo) {
+        return ApiUtils.success(ResponseMessage.PAYMENT_RETRIEVE_SUCCESS.getMessage(), paymentService.getPendingPaymentRequestsByProviderId(authUserInfo));
+    }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #166 

## 📝 작업 내용 요약

- 자신에게 온 결제요청 확인을 위한 테이블 분리
- 결제 완료 및 실패 시 알람 발송

### 📸 스크린샷 (선택)

> 필요한 경우 해당 화면을 캡처하여 첨부해주세요.

## ❓ 리뷰 요청사항 (선택)

> 리뷰 시 집중적으로 봐주었으면 하는 부분이나 고민 중인 사항이 있다면 적어주세요.
>
> ex) 메서드 XXX의 이름을 더 직관적으로 짓고 싶은데, 제안이 있을까요?

## 🔗 관련 링크 (선택)

> 추가적인 정보가 필요하다면 관련 문서나 링크를 제공해주세요.
